### PR TITLE
Recorder metrics now go to tsdb+syslog+udp://localhost:11514

### DIFF
--- a/e2etest/src/test/java/fk/prof/recorder/AssociationTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/AssociationTest.java
@@ -51,17 +51,17 @@ public class AssociationTest {
         runner = new AgentRunner(SleepForever.class.getCanonicalName(), "service_endpoint=http://127.0.0.1:8080," +
                 "ip=10.20.30.40," +
                 "host=foo-host," +
-                "appid=bar-app," +
-                "igrp=baz-grp," +
+                "app_id=bar-app," +
+                "inst_grp=baz-grp," +
                 "cluster=quux-cluster," +
-                "instid=corge-iid," +
+                "inst_id=corge-iid," +
                 "proc=grault-proc," +
-                "vmid=garply-vmid," +
+                "vm_id=garply-vmid," +
                 "zone=waldo-zone," +
-                "ityp=c0.small," +
-                "backoffStart=2," +
-                "backoffMax=5" +
-                "logLvl=trace"
+                "inst_typ=c0.small," +
+                "backoff_start=2," +
+                "backoff_max=5" +
+                "log_lvl=trace"
         );
     }
 

--- a/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
@@ -46,18 +46,18 @@ public class CpuSamplingTest {
     private static final String USUAL_RECORDER_ARGS = "service_endpoint=http://127.0.0.1:8080," +
             "ip=10.20.30.40," +
             "host=foo-host," +
-            "appid=bar-app," +
-            "igrp=baz-grp," +
+            "app_id=bar-app," +
+            "inst_grp=baz-grp," +
             "cluster=quux-cluster," +
-            "instid=corge-iid," +
+            "inst_id=corge-iid," +
             "proc=grault-proc," +
-            "vmid=garply-vmid," +
+            "vm_id=garply-vmid," +
             "zone=waldo-zone," +
-            "ityp=c0.small," +
-            "backoffStart=2," +
-            "backoffMax=5," +
-            "pollItvl=1," +
-            "logLvl=trace";
+            "inst_typ=c0.small," +
+            "backoff_start=2," +
+            "backoff_max=5," +
+            "poll_itvl=1," +
+            "log_lvl=trace";
     private TestBackendServer server;
     private Function<byte[], byte[]>[] association = new Function[2];
     private Function<byte[], byte[]>[] poll = new Function[18];

--- a/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
@@ -57,18 +57,18 @@ public class WorkHandlingTest {
         runner = new AgentRunner(SleepForever.class.getCanonicalName(), "service_endpoint=http://127.0.0.1:8080," +
                 "ip=10.20.30.40," +
                 "host=foo-host," +
-                "appid=bar-app," +
-                "igrp=baz-grp," +
+                "app_id=bar-app," +
+                "inst_grp=baz-grp," +
                 "cluster=quux-cluster," +
-                "instid=corge-iid," +
+                "inst_id=corge-iid," +
                 "proc=grault-proc," +
-                "vmid=garply-vmid," +
+                "vm_id=garply-vmid," +
                 "zone=waldo-zone," +
-                "ityp=c0.small," +
-                "backoffStart=2," +
-                "backoffMax=5," +
-                "pollItvl=1," +
-                "logLvl=trace"
+                "inst_typ=c0.small," +
+                "backoff_start=2," +
+                "backoff_max=5," +
+                "poll_itvl=1," +
+                "log_lvl=trace"
         );
     }
 

--- a/recorder/CMakeLists.txt
+++ b/recorder/CMakeLists.txt
@@ -109,7 +109,9 @@ set(SOURCE_FILES
     ${SRC}/perf_ctx.hh
     ${SRC}/perf_ctx.cc
     ${SRC}/prob_pct.hh
-    ${SRC}/prob_pct.cc)
+    ${SRC}/prob_pct.cc
+    ${SRC}/metric_formatter.hh
+    ${SRC}/metric_formatter.cc)
 
 set(TI_SRC_FILES
     ${SRC}/agent.cc)
@@ -131,6 +133,7 @@ set(TEST_FILES
     ${SRC_TEST}/test_perf_ctx_registry.cc
     ${SRC_TEST}/test_prob_pct.cc
     ${SRC_TEST}/test_blocking_ring_buffer.cc
+    ${SRC_TEST}/test_syslog_tsdb_metric_formatter.cc
     ${SRC_TEST}/test.cc)
 
 set(TEST_UTIL_FILES

--- a/recorder/CMakeLists.txt
+++ b/recorder/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories(${JAVA_INCLUDE_PATH2})
 
 pkg_check_modules(ZLIB REQUIRED zlib)
 pkg_check_modules(CURL REQUIRED libcurl)
-pkg_check_modules(MEDIDA REQUIRED libmedida)
+pkg_check_modules(MEDIDA REQUIRED libmedida>=0.3.0)
 include_directories(${MEDIDA_INCLUDE_DIRS})
 
 if (DEFINED ENV{UNITTEST_INCLUDE_DIRS})

--- a/recorder/src/main/cpp/agent.cc
+++ b/recorder/src/main/cpp/agent.cc
@@ -312,7 +312,7 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved
     GlobalCtx::prob_pct = new ProbPct();
 
     formatter = new MetricFormatter::SyslogTsdbFormatter("proc=" + std::string(CONFIGURATION->proc));
-    metrics_reporter = new medida::reporting::UdpReporter(*GlobalCtx::metrics_registry, *formatter, 11514);
+    metrics_reporter = new medida::reporting::UdpReporter(*GlobalCtx::metrics_registry, *formatter, CONFIGURATION->metrics_dst_port);
     metrics_reporter->start();
     
     controller = new Controller(jvm, jvmti, threadMap, *CONFIGURATION);

--- a/recorder/src/main/cpp/agent.cc
+++ b/recorder/src/main/cpp/agent.cc
@@ -259,6 +259,14 @@ void log_level_self_test() {
     logger->critical(LST "*critical*");
 }
 
+std::string tsdb_tags() {
+    std::string tags = "prefix_override=fkpr";
+    if (CONFIGURATION->proc != nullptr) {
+        tags += (" proc=" + std::string(CONFIGURATION->proc));
+    }
+    return tags;
+}
+
 AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     IMPLICITLY_USE(reserved);
     int err;
@@ -311,7 +319,7 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved
     GlobalCtx::ctx_reg = new PerfCtx::Registry();
     GlobalCtx::prob_pct = new ProbPct();
 
-    formatter = new MetricFormatter::SyslogTsdbFormatter("proc=" + std::string(CONFIGURATION->proc));
+    formatter = new MetricFormatter::SyslogTsdbFormatter(tsdb_tags());
     metrics_reporter = new medida::reporting::UdpReporter(*GlobalCtx::metrics_registry, *formatter, CONFIGURATION->metrics_dst_port);
     metrics_reporter->start();
     

--- a/recorder/src/main/cpp/config.cc
+++ b/recorder/src/main/cpp/config.cc
@@ -57,38 +57,38 @@ void ConfigurationOptions::load(const char* options) {
                 ip = safe_copy_string(value, next);
             } else if (strstr(key, "host") == key) {
                 host = safe_copy_string(value, next);
-            } else if (strstr(key, "appid") == key) {
+            } else if (strstr(key, "app_id") == key) {
                 app_id = safe_copy_string(value, next);
-            } else if (strstr(key, "igrp") == key) {
+            } else if (strstr(key, "inst_grp") == key) {
                 inst_grp = safe_copy_string(value, next);
             } else if (strstr(key, "cluster") == key) {
                 cluster = safe_copy_string(value, next);
-            } else if (strstr(key, "instid") == key) {
+            } else if (strstr(key, "inst_id") == key) {
                 inst_id = safe_copy_string(value, next);
             } else if (strstr(key, "proc") == key) {
                 proc = safe_copy_string(value, next);
-            } else if (strstr(key, "vmid") == key) {
+            } else if (strstr(key, "vm_id") == key) {
                 vm_id = safe_copy_string(value, next);
             } else if (strstr(key, "zone") == key) {
                 zone = safe_copy_string(value, next);
-            } else if (strstr(key, "ityp") == key) {
+            } else if (strstr(key, "inst_typ") == key) {
                 inst_typ = safe_copy_string(value, next);
-            } else if (strstr(key, "backoffStart") == key) {
+            } else if (strstr(key, "backoff_start") == key) {
                 backoff_start = (std::uint32_t) atoi(value);
                 if (backoff_start == 0) backoff_start = MIN_BACKOFF_START;
-            } else if (strstr(key, "backoffMultiplier") == key) {
+            } else if (strstr(key, "backoff_multiplier") == key) {
                 backoff_multiplier = (std::uint32_t) atoi(value);
                 if (backoff_multiplier == 0) backoff_multiplier = DEFAULT_BACKOFF_MULTIPLIER;
-            } else if (strstr(key, "maxRetries") == key) {
+            } else if (strstr(key, "max_retries") == key) {
                 max_retries = (std::uint32_t) atoi(value);
-            } else if (strstr(key, "backoffMax") == key) {
+            } else if (strstr(key, "backoff_max") == key) {
                 backoff_max = (std::uint32_t) atoi(value);
                 if (backoff_max == 0) backoff_max = DEFAULT_BACKOFF_MAX;
-            } else if (strstr(key, "logLvl") == key) {
+            } else if (strstr(key, "log_lvl") == key) {
                 ConfArg val(safe_copy_string(value, next), safe_free_string);
                 log_level = resolv_log_level(val);
                 logger->warn("Log-level set to: {}", log_level);
-            } else if (strstr(key, "pollItvl") == key) {
+            } else if (strstr(key, "poll_itvl") == key) {
                 poll_itvl = (std::uint32_t) atoi(value);
                 if (poll_itvl == 0) poll_itvl = DEFAULT_POLLING_INTERVAL;
             } else {

--- a/recorder/src/main/cpp/config.cc
+++ b/recorder/src/main/cpp/config.cc
@@ -74,23 +74,26 @@ void ConfigurationOptions::load(const char* options) {
             } else if (strstr(key, "inst_typ") == key) {
                 inst_typ = safe_copy_string(value, next);
             } else if (strstr(key, "backoff_start") == key) {
-                backoff_start = (std::uint32_t) atoi(value);
+                backoff_start = static_cast<std::uint32_t>(atoi(value));
                 if (backoff_start == 0) backoff_start = MIN_BACKOFF_START;
             } else if (strstr(key, "backoff_multiplier") == key) {
-                backoff_multiplier = (std::uint32_t) atoi(value);
+                backoff_multiplier = static_cast<std::uint32_t>(atoi(value));
                 if (backoff_multiplier == 0) backoff_multiplier = DEFAULT_BACKOFF_MULTIPLIER;
             } else if (strstr(key, "max_retries") == key) {
-                max_retries = (std::uint32_t) atoi(value);
+                max_retries = static_cast<std::uint32_t>(atoi(value));
             } else if (strstr(key, "backoff_max") == key) {
-                backoff_max = (std::uint32_t) atoi(value);
+                backoff_max = static_cast<std::uint32_t>(atoi(value));
                 if (backoff_max == 0) backoff_max = DEFAULT_BACKOFF_MAX;
             } else if (strstr(key, "log_lvl") == key) {
                 ConfArg val(safe_copy_string(value, next), safe_free_string);
                 log_level = resolv_log_level(val);
                 logger->warn("Log-level set to: {}", log_level);
             } else if (strstr(key, "poll_itvl") == key) {
-                poll_itvl = (std::uint32_t) atoi(value);
+                poll_itvl = static_cast<std::uint32_t>(atoi(value));
                 if (poll_itvl == 0) poll_itvl = DEFAULT_POLLING_INTERVAL;
+            } else if (strstr(key, "metrics_dst_port") == key) {
+                metrics_dst_port = static_cast<std::uint16_t>(atoi(value));
+                if (metrics_dst_port == 0) metrics_dst_port = DEFAULT_METRICS_DEST_PORT;
             } else {
                 logger->warn("Unknown configuration option: {}", key);
             }

--- a/recorder/src/main/cpp/config.hh
+++ b/recorder/src/main/cpp/config.hh
@@ -16,7 +16,9 @@ static const std::uint32_t DEFAULT_MAX_RETRIES = 3;
 static const std::uint32_t MIN_BACKOFF_START = 5;
 static const std::uint32_t DEFAULT_BACKOFF_MAX = 10 * 60;
 static const std::uint32_t DEFAULT_POLLING_INTERVAL = 60;
-    
+
+static const std::uint32_t DEFAULT_METRICS_DEST_PORT = 11514;
+
 struct ConfigurationOptions {
     char* service_endpoint;
     
@@ -39,6 +41,7 @@ struct ConfigurationOptions {
     std::uint32_t poll_itvl;
     
     spdlog::level::level_enum log_level;
+    std::uint16_t metrics_dst_port;
 
     ConfigurationOptions(const char* options) :
         service_endpoint(nullptr),
@@ -53,7 +56,7 @@ struct ConfigurationOptions {
         inst_typ(nullptr),
         backoff_start(MIN_BACKOFF_START), backoff_multiplier(DEFAULT_BACKOFF_MULTIPLIER), backoff_max(DEFAULT_BACKOFF_MAX), max_retries(DEFAULT_MAX_RETRIES),
         poll_itvl(DEFAULT_POLLING_INTERVAL),
-        log_level(spdlog::level::info) {
+        log_level(spdlog::level::info), metrics_dst_port(DEFAULT_METRICS_DEST_PORT) {
         load(options);
     }
 

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -76,6 +76,7 @@ static void populate_recorder_info(recording::RecorderInfo& ri, const Configurat
             ri.set_local_time(now);
         });
     ri.set_recorder_version(RECORDER_VERION);
+    ri.set_recorder_tick(0);
     auto now = Time::now();
     std::chrono::duration<double> uptime = now - start_time;
     ri.set_recorder_uptime(uptime.count());

--- a/recorder/src/main/cpp/metric_formatter.cc
+++ b/recorder/src/main/cpp/metric_formatter.cc
@@ -1,0 +1,65 @@
+#include "metric_formatter.hh"
+
+//
+
+std::string MetricFormatter::hostname() {
+    char buff[HOST_NAME_MAX + 1];
+    if (gethostname(buff, sizeof(buff)) < 0) {
+        return "UNKNOWN";
+    }
+    return buff;
+}
+
+MetricFormatter::SyslogTsdbFormatter::SyslogTsdbFormatter(std::string _tsdb_tags, std::string _tags, std::string _host, std::uint16_t _pri_sev) :
+    tsdb_tags(_tsdb_tags), tags(_tags), host(_host), pri_sev(_pri_sev) { }
+
+MetricFormatter::SyslogTsdbFormatter::~SyslogTsdbFormatter() {}
+
+template <typename... SuffixFrags> void append(std::stringstream& ss) {}
+
+template <typename... SuffixFrags> void append(std::stringstream& ss, const std::string& first, const SuffixFrags&... rest) {
+    ss << "." << first;
+    append(ss, rest...);
+}
+
+template <typename V, typename... SuffixFrags> std::string line(std::uint16_t pri_sev, const std::string& host, const std::string& tags, const std::string& tsdb_tags, const std::string& name, const std::string& type, V v, const SuffixFrags&... suffixes) {
+    std::time_t t = std::time(nullptr);
+    std::tm tm = *std::localtime(&t);
+    char buffer[32];
+    strftime(buffer, sizeof(buffer),"%b %d %H:%M:%S", &tm);
+
+    std::stringstream ss;
+    ss << "<" << pri_sev << ">" << buffer << " " << host << " " << tags << " " << t << " " << name << "." << type;
+    append(ss, suffixes...);
+    ss << " " << v << " " << tsdb_tags;
+    return ss.str();
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, PropName prop, std::uint64_t val) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, prop);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, PropName prop, std::int64_t val) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, prop);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, PropName prop, double val) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, prop);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, PropName prop, std::uint64_t val, Unit unit) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, prop, unit);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, PropName prop, double val, Unit unit) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, prop, unit);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, EventType evt_typ, PropName prop, std::uint64_t val, Unit unit) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, evt_typ, prop, unit);
+}
+
+std::string MetricFormatter::SyslogTsdbFormatter::operator()(MetricType type, EventType evt_typ, PropName prop, double val, Unit unit) {
+    return line(pri_sev, host, tags, tsdb_tags, *name, type, val, evt_typ, prop, unit);
+}
+

--- a/recorder/src/main/cpp/metric_formatter.cc
+++ b/recorder/src/main/cpp/metric_formatter.cc
@@ -25,11 +25,11 @@ template <typename... SuffixFrags> void append(std::stringstream& ss, const std:
 template <typename V, typename... SuffixFrags> std::string line(std::uint16_t pri_sev, const std::string& host, const std::string& tags, const std::string& tsdb_tags, const std::string& name, const std::string& type, V v, const SuffixFrags&... suffixes) {
     std::time_t t = std::time(nullptr);
     std::tm tm = *std::localtime(&t);
-    char buffer[32];
-    strftime(buffer, sizeof(buffer),"%b %d %H:%M:%S", &tm);
+    char now_str[32];
+    strftime(now_str, sizeof(now_str),"%b %d %H:%M:%S", &tm);
 
     std::stringstream ss;
-    ss << "<" << pri_sev << ">" << buffer << " " << host << " " << tags << " " << t << " " << name << "." << type;
+    ss << "<" << pri_sev << ">" << now_str << " " << host << " " << tags << " " << t << " " << name << "." << type;
     append(ss, suffixes...);
     ss << " " << v << " " << tsdb_tags;
     return ss.str();

--- a/recorder/src/main/cpp/metric_formatter.hh
+++ b/recorder/src/main/cpp/metric_formatter.hh
@@ -1,0 +1,40 @@
+#ifndef METRIC_FORMATTER_H
+#define METRIC_FORMATTER_H
+
+#include "globals.hh"
+#include <algorithm>
+#include "metrics.hh"
+#include "util.hh"
+#include <unistd.h>
+#include <limits.h>
+
+namespace MetricFormatter {
+    std::string hostname();
+    
+    class SyslogTsdbFormatter : public medida::reporting::UdpReporter::Formatter {
+    private:
+        const std::string tsdb_tags;
+        const std::string tags;
+        const std::string host;
+        const std::uint16_t pri_sev;
+        
+    public:
+        SyslogTsdbFormatter(std::string tsdb_tags, std::string tags = "fkprof", std::string host = hostname(), std::uint16_t pri_sev = 128);
+        ~SyslogTsdbFormatter();
+
+        typedef medida::reporting::UdpReporter::MetricType MetricType;
+        typedef medida::reporting::UdpReporter::PropName PropName;
+        typedef medida::reporting::UdpReporter::Unit Unit;
+        typedef medida::reporting::UdpReporter::EventType EventType;
+
+        std::string operator()(MetricType type, PropName prop, std::uint64_t val);
+        std::string operator()(MetricType type, PropName prop, std::int64_t val);
+        std::string operator()(MetricType type, PropName prop, double val);
+        std::string operator()(MetricType type, PropName prop, std::uint64_t val, Unit unit);
+        std::string operator()(MetricType type, PropName prop, double val, Unit unit);
+        std::string operator()(MetricType type, EventType evt_typ, PropName prop, std::uint64_t val, Unit unit);
+        std::string operator()(MetricType type, EventType evt_typ, PropName prop, double val, Unit unit);
+    };
+}
+
+#endif

--- a/recorder/src/test/cpp/test_config.cc
+++ b/recorder/src/test/cpp/test_config.cc
@@ -11,20 +11,20 @@ TEST(ParsesAllOptions) {
     std::string str("service_endpoint=http://10.20.30.40:9070,"
                     "ip=50.60.70.80,"
                     "host=foo.host,"
-                    "appid=bar_app,"
-                    "igrp=baz_grp,"
+                    "app_id=bar_app,"
+                    "inst_grp=baz_grp,"
                     "cluster=quux_cluster,"
-                    "instid=corge_iid,"
+                    "inst_id=corge_iid,"
                     "proc=grault_proc,"
-                    "vmid=garply_vmid,"
+                    "vm_id=garply_vm_id,"
                     "zone=waldo_zone,"
-                    "ityp=c0.medium,"
-                    "backoffStart=2,"
-                    "backoffMultiplier=3,"
-                    "maxRetries=7,"
-                    "backoffMax=15,"
-                    "logLvl=warn,"
-                    "pollItvl=30");
+                    "inst_type=c0.medium,"
+                    "backoff_start=2,"
+                    "backoff_multiplier=3,"
+                    "max_retries=7,"
+                    "backoff_max=15,"
+                    "log_lvl=warn,"
+                    "poll_itvl=30");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -35,7 +35,7 @@ TEST(ParsesAllOptions) {
     CHECK_EQUAL("quux_cluster", options.cluster);
     CHECK_EQUAL("corge_iid", options.inst_id);
     CHECK_EQUAL("grault_proc", options.proc);
-    CHECK_EQUAL("garply_vmid", options.vm_id);
+    CHECK_EQUAL("garply_vm_id", options.vm_id);
     CHECK_EQUAL("waldo_zone", options.zone);
     CHECK_EQUAL("c0.medium", options.inst_typ);
     CHECK_EQUAL(2, options.backoff_start);
@@ -52,14 +52,14 @@ TEST(DefaultAppropriately) {
     std::string str("service_endpoint=http://10.20.30.40:9070,"
                     "ip=50.60.70.80,"
                     "host=foo.host,"
-                    "appid=bar_app,"
-                    "igrp=baz_grp,"
+                    "app_id=bar_app,"
+                    "inst_grp=baz_grp,"
                     "cluster=quux_cluster,"
-                    "instid=corge_iid,"
+                    "inst_id=corge_iid,"
                     "proc=grault_proc,"
-                    "vmid=garply_vmid,"
+                    "vm_id=garply_vm_id,"
                     "zone=waldo_zone,"
-                    "ityp=c0.medium");
+                    "inst_type=c0.medium");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -70,7 +70,7 @@ TEST(DefaultAppropriately) {
     CHECK_EQUAL("quux_cluster", options.cluster);
     CHECK_EQUAL("corge_iid", options.inst_id);
     CHECK_EQUAL("grault_proc", options.proc);
-    CHECK_EQUAL("garply_vmid", options.vm_id);
+    CHECK_EQUAL("garply_vm_id", options.vm_id);
     CHECK_EQUAL("waldo_zone", options.zone);
     CHECK_EQUAL("c0.medium", options.inst_typ);
     CHECK_EQUAL(5, options.backoff_start);

--- a/recorder/src/test/cpp/test_config.cc
+++ b/recorder/src/test/cpp/test_config.cc
@@ -24,7 +24,8 @@ TEST(ParsesAllOptions) {
                     "max_retries=7,"
                     "backoff_max=15,"
                     "log_lvl=warn,"
-                    "poll_itvl=30");
+                    "poll_itvl=30,"
+                    "metrics_dst_port=10203");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -44,7 +45,7 @@ TEST(ParsesAllOptions) {
     CHECK_EQUAL(15, options.backoff_max);
     CHECK_EQUAL(spdlog::level::warn, options.log_level);
     CHECK_EQUAL(30, options.poll_itvl);
-
+    CHECK_EQUAL(10203, options.metrics_dst_port);
 }
 
 TEST(DefaultAppropriately) {
@@ -79,6 +80,7 @@ TEST(DefaultAppropriately) {
     CHECK_EQUAL(10 * 60, options.backoff_max);
     CHECK_EQUAL(spdlog::level::info, options.log_level);
     CHECK_EQUAL(60, options.poll_itvl);
+    CHECK_EQUAL(11514, options.metrics_dst_port);
 }
 
 TEST(SafelyTerminatesStrings) {

--- a/recorder/src/test/cpp/test_syslog_tsdb_metric_formatter.cc
+++ b/recorder/src/test/cpp/test_syslog_tsdb_metric_formatter.cc
@@ -1,0 +1,266 @@
+#include "../../main/cpp/metric_formatter.hh"
+#include "test.hh"
+#include <ctime>
+
+#include <regex>
+#include <string>
+#include <unistd.h>
+#include <limits.h>
+
+std::string time_now() {
+    std::time_t t = std::time(nullptr);
+    std::tm tm = *std::localtime(&t);
+    char buffer[120];
+    strftime(buffer, sizeof(buffer),"%b %d %H:%M:%S", &tm);
+    return std::string(buffer);
+}
+
+std::uint64_t seconds_since_epoch() {
+    return std::time(nullptr);
+}
+
+#define ASSERT_IS_BETWEEN(start, end, value)    \
+    {                                           \
+        CHECK(value >= start);                  \
+        CHECK(value <= end);                    \
+    }
+
+#define TM_AT(name)                                    \
+    std::string name##_str = time_now();               \
+    std::uint64_t name##_ts = time(nullptr);
+
+
+struct SyslogTsdbMsg {
+    //syslog stuff
+    std::uint16_t pri_sev;
+    std::string tm;
+    std::string host;
+    std::string tag;
+
+    //TSDB stuff
+    std::uint64_t tsd_ts;
+    std::string tsd_metric;
+    std::string tsd_value;
+    std::string tsd_tags;
+};
+
+void parse(const std::string& msg, SyslogTsdbMsg& stm) {
+    std::regex r("<(\\d+)>(\\S+ \\d+ \\d+:\\d+:\\d+) (\\S+) (\\S+) (\\d+) (\\S+) (\\d+.?\\d*) (.+)");
+    std::smatch m;
+
+    assert(std::regex_match(msg, m, r));
+    assert(m.size() == 9);
+
+    stm.pri_sev = std::stoi(m[1]); 
+    stm.tm = m[2];
+    stm.host = m[3];
+    stm.tag = m[4];
+
+    stm.tsd_ts = std::stol(m[5]);
+    stm.tsd_metric = m[6];
+    stm.tsd_value = m[7];
+    stm.tsd_tags = m[8];
+}
+
+TEST(Parsing_helper) {
+    SyslogTsdbMsg stm;
+    parse("<128>Mar 15 19:03:13 prod-log-rcvr-bv1-382760 stream.cosmos 1489584793 logsvc.rcvr.rcvd.low 5941 app_and_cluster=elb//NULL/ app_id=elb cluster=/NULL/ app=prod-log zone=in-chennai-1 type=c1.medium group=rcvr-bv1 _version=3.0.11 _collector=cosmos-base host=prod-log-rcvr-bv1-382760", stm);
+    
+    CHECK_EQUAL(128, stm.pri_sev);
+    CHECK_EQUAL("Mar 15 19:03:13", stm.tm);
+    CHECK_EQUAL("prod-log-rcvr-bv1-382760", stm.host);
+    CHECK_EQUAL("stream.cosmos", stm.tag);
+    CHECK_EQUAL(1489584793, stm.tsd_ts);
+    CHECK_EQUAL("logsvc.rcvr.rcvd.low", stm.tsd_metric);
+    CHECK_EQUAL("5941", stm.tsd_value);
+    CHECK_EQUAL("app_and_cluster=elb//NULL/ app_id=elb cluster=/NULL/ app=prod-log zone=in-chennai-1 type=c1.medium group=rcvr-bv1 _version=3.0.11 _collector=cosmos-base host=prod-log-rcvr-bv1-382760", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_unitless_uint64) {
+    MetricFormatter::SyslogTsdbFormatter stf("quux=corge grault=garply", "foo,bar", "baz.host", 126);
+
+    std::string name = "thermometer";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("temp", "gradiant", static_cast<std::uint64_t>(100));
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(126, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("baz.host", stm.host);
+    CHECK_EQUAL("foo,bar", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("thermometer.temp.gradiant", stm.tsd_metric);
+    CHECK_EQUAL("100", stm.tsd_value);
+    CHECK_EQUAL("quux=corge grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_unitless_int64) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "pressure";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_nozzle", "differential", static_cast<std::int64_t>(120));
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("pressure.near_nozzle.differential", stm.tsd_metric);
+    CHECK_EQUAL("120", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_unitless_double) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "pressure";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_nozzle", "differential", static_cast<double>(120.3));
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("pressure.near_nozzle.differential", stm.tsd_metric);
+    CHECK_EQUAL("120.3", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_uintt64_with_unit) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "pressure";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_nozzle", "differential", static_cast<std::uint64_t>(120), "psi");
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("pressure.near_nozzle.differential.psi", stm.tsd_metric);
+    CHECK_EQUAL("120", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_double_with_unit) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "pressure";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_nozzle", "differential", static_cast<double>(120.1), "psi");
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("pressure.near_nozzle.differential.psi", stm.tsd_metric);
+    CHECK_EQUAL("120.1", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_uint64_with_unit__and__event_type) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "temprature";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_surface", "alcohol_thermometer", "10_min_avg", static_cast<std::uint64_t>(85), "C");
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("temprature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
+    CHECK_EQUAL("85", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_format_double_with_unit__and__event_type) {
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
+
+    std::string name = "temprature";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("near_surface", "alcohol_thermometer", "10_min_avg", static_cast<double>(85.7), "C");
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL("quux", stm.host);
+    CHECK_EQUAL("bar,foo", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("temprature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
+    CHECK_EQUAL("85.7", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+
+TEST(SyslogTsdbFormatter__should_default_everything_sensibly) {
+    char buff[HOST_NAME_MAX + 1];
+    assert(gethostname(buff, sizeof(buff)) == 0);
+    std::string actual_hostname(buff);
+    
+    MetricFormatter::SyslogTsdbFormatter stf("grault=garply");
+
+    std::string name = "thermometer";
+    stf.set_name(name);
+
+    TM_AT(start);
+    auto msg = stf("temp", "gradiant", static_cast<std::uint64_t>(100));
+    TM_AT(end);
+
+    SyslogTsdbMsg stm;
+    parse(msg, stm);
+
+    CHECK_EQUAL(128, stm.pri_sev);
+    ASSERT_IS_BETWEEN(start_str, end_str, stm.tm);
+    CHECK_EQUAL(actual_hostname, stm.host);
+    CHECK_EQUAL("fkprof", stm.tag);
+    ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
+    CHECK_EQUAL("thermometer.temp.gradiant", stm.tsd_metric);
+    CHECK_EQUAL("100", stm.tsd_value);
+    CHECK_EQUAL("grault=garply", stm.tsd_tags);
+}
+

--- a/recorder/src/test/cpp/test_syslog_tsdb_metric_formatter.cc
+++ b/recorder/src/test/cpp/test_syslog_tsdb_metric_formatter.cc
@@ -83,7 +83,7 @@ TEST(SyslogTsdbFormatter__should_format_unitless_uint64) {
     stf.set_name(name);
 
     TM_AT(start);
-    auto msg = stf("temp", "gradiant", static_cast<std::uint64_t>(100));
+    auto msg = stf("temp", "gradient", static_cast<std::uint64_t>(100));
     TM_AT(end);
 
     SyslogTsdbMsg stm;
@@ -94,7 +94,7 @@ TEST(SyslogTsdbFormatter__should_format_unitless_uint64) {
     CHECK_EQUAL("baz.host", stm.host);
     CHECK_EQUAL("foo,bar", stm.tag);
     ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
-    CHECK_EQUAL("thermometer.temp.gradiant", stm.tsd_metric);
+    CHECK_EQUAL("thermometer.temp.gradient", stm.tsd_metric);
     CHECK_EQUAL("100", stm.tsd_value);
     CHECK_EQUAL("quux=corge grault=garply", stm.tsd_tags);
 }
@@ -194,7 +194,7 @@ TEST(SyslogTsdbFormatter__should_format_double_with_unit) {
 TEST(SyslogTsdbFormatter__should_format_uint64_with_unit__and__event_type) {
     MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
 
-    std::string name = "temprature";
+    std::string name = "temperature";
     stf.set_name(name);
 
     TM_AT(start);
@@ -209,7 +209,7 @@ TEST(SyslogTsdbFormatter__should_format_uint64_with_unit__and__event_type) {
     CHECK_EQUAL("quux", stm.host);
     CHECK_EQUAL("bar,foo", stm.tag);
     ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
-    CHECK_EQUAL("temprature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
+    CHECK_EQUAL("temperature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
     CHECK_EQUAL("85", stm.tsd_value);
     CHECK_EQUAL("grault=garply", stm.tsd_tags);
 }
@@ -217,7 +217,7 @@ TEST(SyslogTsdbFormatter__should_format_uint64_with_unit__and__event_type) {
 TEST(SyslogTsdbFormatter__should_format_double_with_unit__and__event_type) {
     MetricFormatter::SyslogTsdbFormatter stf("grault=garply", "bar,foo", "quux", 128);
 
-    std::string name = "temprature";
+    std::string name = "temperature";
     stf.set_name(name);
 
     TM_AT(start);
@@ -232,7 +232,7 @@ TEST(SyslogTsdbFormatter__should_format_double_with_unit__and__event_type) {
     CHECK_EQUAL("quux", stm.host);
     CHECK_EQUAL("bar,foo", stm.tag);
     ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
-    CHECK_EQUAL("temprature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
+    CHECK_EQUAL("temperature.near_surface.alcohol_thermometer.10_min_avg.C", stm.tsd_metric);
     CHECK_EQUAL("85.7", stm.tsd_value);
     CHECK_EQUAL("grault=garply", stm.tsd_tags);
 }
@@ -248,7 +248,7 @@ TEST(SyslogTsdbFormatter__should_default_everything_sensibly) {
     stf.set_name(name);
 
     TM_AT(start);
-    auto msg = stf("temp", "gradiant", static_cast<std::uint64_t>(100));
+    auto msg = stf("temp", "gradient", static_cast<std::uint64_t>(100));
     TM_AT(end);
 
     SyslogTsdbMsg stm;
@@ -259,7 +259,7 @@ TEST(SyslogTsdbFormatter__should_default_everything_sensibly) {
     CHECK_EQUAL(actual_hostname, stm.host);
     CHECK_EQUAL("fkprof", stm.tag);
     ASSERT_IS_BETWEEN(start_ts, end_ts, stm.tsd_ts);
-    CHECK_EQUAL("thermometer.temp.gradiant", stm.tsd_metric);
+    CHECK_EQUAL("thermometer.temp.gradient", stm.tsd_metric);
     CHECK_EQUAL("100", stm.tsd_value);
     CHECK_EQUAL("grault=garply", stm.tsd_tags);
 }


### PR DESCRIPTION
It depends on medida 0.3.0+ (which has udp-reporting support). 

The formatter is externalized, so we provide one that builds syslog(tsdb) encaped packets.

The reporter simply sends it to the UDP dest.

Medida changes are on the master branch here: https://github.com/janmejay/medida

This PR also fakes recorder_tick by always setting it to 0, so existing integration tests pass.

Those tests use a fake aggregator/backend so they don't care about the 0 value and no assert has been added for it, so it just works. As of now master is broken, so this change was necessary.

Will fix it for real in another PR.

