### PR TITLE
Some recorder fixes

### DIFF
--- a/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
@@ -58,6 +58,7 @@ public class CpuSamplingTest {
             "backoff_max=5," +
             "poll_itvl=1," +
             "log_lvl=trace";
+    private static final String NOCTX_NAME = "~ OTHERS ~";
     private TestBackendServer server;
     private Function<byte[], byte[]>[] association = new Function[2];
     private Function<byte[], byte[]>[] poll = new Function[18];
@@ -138,15 +139,17 @@ public class CpuSamplingTest {
 
         assertRecordingHeaderIsGood(cpuSamplingWorkIssueTime, hdr, CPU_SAMPLING_MAX_FRAMES);
 
-        assertProfileCallAndContent(profileCalledSecondTime, profileEntries, Collections.singletonMap("inferno",
-                rootMatcher(DUMMY_ROOT_NODE_FN_NAME, DUMMY_ROOT_NOTE_FN_SIGNATURE, 0, 1, childrenMatcher(
-                        nodeMatcher(Burn20And80PctCpu.class, "main", "([Ljava/lang/String;)V", 0, 1, childrenMatcher(
-                                nodeMatcher(Burn20And80PctCpu.class, "burnCpu", "()V", 0, 1, childrenMatcher(
-                                        nodeMatcher(Burn20Of100.class, "burn", "()V", 0, 1, childrenMatcher(
-                                                nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", 20, 10, Collections.emptySet()))),
-                                        nodeMatcher(WrapperA.class, "burnSome", "(S)V", 0, 1, childrenMatcher(
-                                                nodeMatcher(Burn80Of100.class, "burn", "()V", 0, 1, childrenMatcher(
-                                                        nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", 80, 10, Collections.emptySet())))))))))))), new TraceIdPivotResolver(), new HashMap<Integer, TraceInfo>(), new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), new HashMap<String, SampledStackNode>());
+        assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
+            put(NOCTX_NAME, zeroSampleRoot());
+            put("inferno", rootMatcher(childrenMatcher(
+                    nodeMatcher(Burn20And80PctCpu.class, "main", "([Ljava/lang/String;)V", 0, 1, childrenMatcher(
+                            nodeMatcher(Burn20And80PctCpu.class, "burnCpu", "()V", 0, 1, childrenMatcher(
+                                    nodeMatcher(Burn20Of100.class, "burn", "()V", 0, 1, childrenMatcher(
+                                            nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", 20, 10, Collections.emptySet()))),
+                                    nodeMatcher(WrapperA.class, "burnSome", "(S)V", 0, 1, childrenMatcher(
+                                            nodeMatcher(Burn80Of100.class, "burn", "()V", 0, 1, childrenMatcher(
+                                                    nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", 80, 10, Collections.emptySet()))))))))))));
+        }}, new TraceIdPivotResolver(), new HashMap<Integer, TraceInfo>(), new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), new HashMap<String, SampledStackNode>());
     }
 
     @Test
@@ -177,13 +180,14 @@ public class CpuSamplingTest {
         HashMap<String, SampledStackNode> aggregations = new HashMap<>();
         assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
             Class klass = Burn50And50PctCpu.class;
-            put("100_pct_single_inferno", generate_Main_Burn_Immolate_BacktraceMatcher(66, klass));
-            put("50_pct_duplicate_inferno", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass));
-            put("50_pct_duplicate_inferno_child", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass));
+            put(NOCTX_NAME, zeroSampleRoot());
+            put("100_pct_single_inferno", generate_Main_Burn_Immolate_BacktraceMatcher(66, klass, 25));
+            put("50_pct_duplicate_inferno", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass, 25));
+            put("50_pct_duplicate_inferno_child", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass, 25));
         }}, new TraceIdPivotResolver(), traceInfoMap, new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), aggregations);
-        
+
         assertThat(traceInfoMap.values(), hasItems(new TraceInfo("100_pct_single_inferno", 100, MergeSemantics.MERGE_TO_PARENT), new TraceInfo("50_pct_duplicate_inferno", 50, MergeSemantics.MERGE_TO_PARENT), new TraceInfo("50_pct_duplicate_inferno_child", 50, MergeSemantics.DUPLICATE)));
-        
+
         //check BCI and Line-no was posted correctly, blackhole consumeCPU call should almost always be on stack 
 
         Map<ImmutablePair<Integer, Integer>, MutableInt> bci_lineNo_Histo = new HashMap<>();
@@ -202,10 +206,10 @@ public class CpuSamplingTest {
             }
             allCallSites += ctr;
         }
-        
-        double ratio = (double) blackholeCallSites /  allCallSites;
+
+        double ratio = (double) blackholeCallSites / allCallSites;
         double expectedMin = 0.9;
-        assertThat("The line-no/bci distribution was somehow not right (expected " + expectedMin + "x calls to be on hot fn call-site, but it was only " + ratio + "x (details: "  + bci_lineNo_Histo + ")", ratio, greaterThan(expectedMin));
+        assertThat("The line-no/bci distribution was somehow not right (expected " + expectedMin + "x calls to be on hot fn call-site, but it was only " + ratio + "x (details: " + bci_lineNo_Histo + ")", ratio, greaterThan(expectedMin));
     }
 
     private void buildBciLineNoHistogram(SampledStackNode node, Map<ImmutablePair<Integer, Integer>, MutableInt> bci_lineNo_histo, Class klass, String fnName, String sig) {
@@ -231,11 +235,11 @@ public class CpuSamplingTest {
         }
     }
 
-    private StackNodeMatcher generate_Main_Burn_Immolate_BacktraceMatcher(final int expectedOncpuPct, final Class klass) {
-        return rootMatcher(DUMMY_ROOT_NODE_FN_NAME, DUMMY_ROOT_NOTE_FN_SIGNATURE, 0, 1, childrenMatcher(
+    private StackNodeMatcher generate_Main_Burn_Immolate_BacktraceMatcher(final int expectedOncpuPct, final Class klass, final int pctMatchTolerance) {
+        return rootMatcher(childrenMatcher(
                 nodeMatcher(klass, "main", "([Ljava/lang/String;)V", 0, 1, childrenMatcher(
                         nodeMatcher(klass, "immolate", "(I)V", 0, 1, childrenMatcher(
-                                nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", expectedOncpuPct, 25, Collections.emptySet())))))));
+                                nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", expectedOncpuPct, pctMatchTolerance, Collections.emptySet())))))));
     }
 
     @Test
@@ -302,9 +306,10 @@ public class CpuSamplingTest {
         HashMap<Integer, TraceInfo> traceInfoMap = new HashMap<>();
         assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
             Class klass = BurnCpuScoped.class;
-            put("p100", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass));
-            put("p100 > c1", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass));
-            put("p100 > c1 > c2", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass));
+            put(NOCTX_NAME, zeroSampleRoot());
+            put("p100", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass, 25));
+            put("p100 > c1", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass, 25));
+            put("p100 > c1 > c2", generate_Main_Burn_Immolate_BacktraceMatcher(33, klass, 25));
         }}, new TraceIdPivotResolver(), traceInfoMap, new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), new HashMap<String, SampledStackNode>());
         assertThat(traceInfoMap.values(), hasItems(
                 new TraceInfo("p100", 100, MergeSemantics.STACK_UP),
@@ -339,14 +344,58 @@ public class CpuSamplingTest {
         HashMap<Integer, TraceInfo> traceInfoMap = new HashMap<>();
         assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
             Class klass = BurnCpuStacked.class;
-            put("p50", generate_Main_Burn_Immolate_BacktraceMatcher(25, klass));
-            put("c100", generate_Main_Burn_Immolate_BacktraceMatcher(50, klass));
+            put(NOCTX_NAME, zeroSampleRoot());
+            put("p50", generate_Main_Burn_Immolate_BacktraceMatcher(25, klass, 25));
+            put("c100", generate_Main_Burn_Immolate_BacktraceMatcher(50, klass, 25));
         }}, new TraceIdPivotResolver(), traceInfoMap, new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), new HashMap<String, SampledStackNode>());
         assertThat(traceInfoMap.values(), hasItems(
                 new TraceInfo("p50", 50, MergeSemantics.PARENT_SCOPED),
                 new TraceInfo("c100", 100, MergeSemantics.STACK_UP)));
     }
-    
+
+    private StackNodeMatcher zeroSampleRoot() {
+        return rootMatcher(Collections.emptySet());
+    }
+
+    private StackNodeMatcher rootMatcher(Set<StackNodeMatcher> children) {
+        return rootMatcher(DUMMY_ROOT_NODE_FN_NAME, DUMMY_ROOT_NOTE_FN_SIGNATURE, 0, 1, children);
+    }
+
+    @Test
+    public void should_Report_NoCtxData() throws ExecutionException, InterruptedException, IOException, TimeoutException {
+        List<Recorder.Wse> profileEntries = new ArrayList<>();
+        MutableObject<Recorder.RecordingHeader> hdr = new MutableObject<>();
+        MutableBoolean profileCalledSecondTime = new MutableBoolean(false);
+        String cpuSamplingWorkIssueTime = ISODateTimeFormat.dateTime().print(DateTime.now());
+
+        PollReqWithTime[] pollReqs = stubRecorderInteraction(profileEntries, hdr, profileCalledSecondTime, cpuSamplingWorkIssueTime, WorkHandlingTest.CPU_SAMPLING_MAX_FRAMES);
+
+        runner = new AgentRunner(BurnHalfInHalfOut.class.getCanonicalName(), USUAL_RECORDER_ARGS + ",noctx_cov_pct=50");
+        runner.start();
+
+        assocAction[0].get(4, TimeUnit.SECONDS);
+        long prevTime = System.currentTimeMillis();
+
+        assertThat(assocAction[0].isDone(), is(true));
+        pollAction[poll.length - 1].get(poll.length + 4, TimeUnit.SECONDS); //some grace time
+
+        assertPollIntervalIsGood(pollReqs, prevTime);
+
+        assertPolledInStatusIsGood(pollReqs);
+
+        assertRecordingHeaderIsGood(cpuSamplingWorkIssueTime, hdr, CPU_SAMPLING_MAX_FRAMES);
+
+        HashMap<Integer, TraceInfo> traceInfoMap = new HashMap<>();
+        assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
+            Class klass = BurnHalfInHalfOut.class;
+            put(NOCTX_NAME, generate_Main_Burn_Immolate_BacktraceMatcher(25, klass, 20));
+            put("c100", generate_Main_Burn_Immolate_BacktraceMatcher(50, klass, 20));
+        }}, new TraceIdPivotResolver(), traceInfoMap, new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), new HashMap<String, SampledStackNode>());
+        assertThat(traceInfoMap.values(), hasItems(
+                new TraceInfo(NOCTX_NAME, 50, MergeSemantics.MERGE_TO_PARENT),
+                new TraceInfo("c100", 100, MergeSemantics.MERGE_TO_PARENT)));
+    }
+
     @Test
     public void should_SnipBacktrace_ToChosenLength() throws ExecutionException, InterruptedException, IOException, TimeoutException {
         List<Recorder.Wse> profileEntries = new ArrayList<>();
@@ -374,7 +423,8 @@ public class CpuSamplingTest {
 
         HashMap<String, SampledStackNode> aggregation = new HashMap<>();
         assertProfileCallAndContent(profileCalledSecondTime, profileEntries, new HashMap<String, StackNodeMatcher>() {{
-            put("inferno", rootMatcher(DUMMY_ROOT_NODE_FN_NAME, DUMMY_ROOT_NOTE_FN_SIGNATURE, 0, 1, childrenMatcher(
+            put(NOCTX_NAME, zeroSampleRoot());
+            put("inferno", rootMatcher(childrenMatcher(
                     nodeMatcher(CpuBurningRunnable.class, "run", "()V", 0, 1, childrenMatcher(
                             nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", 100, 10, Collections.emptySet()))))));
         }}, new TraceIdPivotResolver(), new HashMap<>(), new HashMap<Integer, ThreadInfo>(), new HashMap<Long, MthdInfo>(), aggregation);
@@ -398,7 +448,7 @@ public class CpuSamplingTest {
     }
 
     private StackNodeMatcher generate_Thread_Runnable_Immolate_BacktraceMatcher(final int expectedOncpuPct) {
-        return rootMatcher(DUMMY_ROOT_NODE_FN_NAME, DUMMY_ROOT_NOTE_FN_SIGNATURE, 0, 1, childrenMatcher(
+        return rootMatcher(childrenMatcher(
                 nodeMatcher(Thread.class, "run", "()V", 0, 1, childrenMatcher(
                         nodeMatcher(CpuBurningRunnable.class, "run", "()V", 0, 1, childrenMatcher(
                                 nodeMatcher(Blackhole.class, "consumeCPU", "(J)V", expectedOncpuPct, 20, Collections.emptySet())))))));
@@ -674,6 +724,9 @@ public class CpuSamplingTest {
                 }
             }
         }
+
+        //debug aid, the thing is almost a json, just a little top-level key-massaging is necessary (massage and use 'jq')
+        //System.out.println("aggregations = " + aggregations);
 
         //now let us match it
         for (Map.Entry<String, StackNodeMatcher> expectedEntry : expected.entrySet()) {

--- a/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
@@ -6,6 +6,7 @@ import fk.prof.recorder.utils.AgentRunner;
 import fk.prof.recorder.utils.TestBackendServer;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.After;
@@ -111,8 +112,11 @@ public class WorkHandlingTest {
         pollAction[poll.length - 1].get(poll.length + 4, TimeUnit.SECONDS); //some grace time
 
         long idx = 0;
+        Matcher<Long> recorderTickMatcher = is(0l);
+        long previousTick;
         for (PollReqWithTime prwt : pollReqs) {
-            assertRecorderInfoAllGood(prwt.req.getRecorderInfo());
+            previousTick = AssociationTest.assertRecorderInfoAllGood_AndGetTick(prwt.req.getRecorderInfo(), recorderTickMatcher);
+            recorderTickMatcher = greaterThan(previousTick);
             assertItHadNoWork(prwt.req.getWorkLastIssued(), idx == 0 ? idx : idx + 99);
             if (idx > 0) {
                 assertThat("idx = " + idx, prwt.time - prevTime, approximatelyBetween(1000l, 2000l)); //~1 sec tolerance
@@ -148,8 +152,11 @@ public class WorkHandlingTest {
         pollAction[poll.length - 1].get(poll.length + 4, TimeUnit.SECONDS); //some grace time
 
         long idx = 0;
+        Matcher<Long> recorderTickMatcher = is(0l);
+        long previousTick;
         for (PollReqWithTime prwt : pollReqs) {
-            assertRecorderInfoAllGood(prwt.req.getRecorderInfo());
+            previousTick = AssociationTest.assertRecorderInfoAllGood_AndGetTick(prwt.req.getRecorderInfo(), recorderTickMatcher);
+            recorderTickMatcher = greaterThan(previousTick);
             if (idx > 0) {
                 assertThat(prwt.time - prevTime, approximatelyBetween(1000l, 2000l)); //~1 sec tolerance
             }
@@ -206,15 +213,7 @@ public class WorkHandlingTest {
         assertThat(assocAction[0].isDone(), is(true));
         pollAction[poll.length - 1].get(poll.length + 4, TimeUnit.SECONDS); //some grace time
 
-        long idx = 0;
-        for (PollReqWithTime prwt : pollReqs) {
-            assertRecorderInfoAllGood(prwt.req.getRecorderInfo());
-            if (idx > 0) {
-                assertThat("idx = " + idx, prwt.time - prevTime, approximatelyBetween(1000l, 2000l)); //~1 sec tolerance
-            }
-            prevTime = prwt.time;
-            idx++;
-        }
+        assertPollingWasAllGood(pollReqs, prevTime);
 
         assertWorkStateAndResultIs(pollReqs[0].req.getWorkLastIssued(), 0, Recorder.WorkResponse.WorkState.complete, Recorder.WorkResponse.WorkResult.success, 0);
         assertWorkStateAndResultIs(pollReqs[1].req.getWorkLastIssued(), 100, Recorder.WorkResponse.WorkState.complete, Recorder.WorkResponse.WorkResult.success, 0);
@@ -239,6 +238,21 @@ public class WorkHandlingTest {
         assertRecordingHeaderIsGood(hdr.getValue(), CONTROLLER_ID, CPU_SAMPLING_WORK_ID, cpuSamplingWorkIssueTime, 10, 2, 1, new Recorder.Work[] {w});
         
         assertThat(profileCalledSecondTime.getValue(), is(false));
+    }
+
+    private void assertPollingWasAllGood(PollReqWithTime[] pollReqs, long prevTime) {
+        long idx = 0;
+        Matcher<Long> recorderTickMatcher = is(0l);
+        long previousTick;
+        for (PollReqWithTime prwt : pollReqs) {
+            previousTick = AssociationTest.assertRecorderInfoAllGood_AndGetTick(prwt.req.getRecorderInfo(), recorderTickMatcher);
+            recorderTickMatcher = greaterThan(previousTick);
+            if (idx > 0) {
+                assertThat("idx = " + idx, prwt.time - prevTime, approximatelyBetween(1000l, 2000l)); //~1 sec tolerance
+            }
+            prevTime = prwt.time;
+            idx++;
+        }
     }
 
     @Test
@@ -273,15 +287,7 @@ public class WorkHandlingTest {
         assertThat(assocAction[0].isDone(), is(true));
         pollAction[poll.length - 1].get(poll.length + 4, TimeUnit.SECONDS); //some grace time
 
-        long idx = 0;
-        for (PollReqWithTime prwt : pollReqs) {
-            assertRecorderInfoAllGood(prwt.req.getRecorderInfo());
-            if (idx > 0) {
-                assertThat("idx = " + idx, prwt.time - prevTime, approximatelyBetween(1000l, 2000l)); //~1 sec tolerance
-            }
-            prevTime = prwt.time;
-            idx++;
-        }
+        assertPollingWasAllGood(pollReqs, prevTime);
 
         assertWorkStateAndResultIs(pollReqs[0].req.getWorkLastIssued(), 0, Recorder.WorkResponse.WorkState.complete, Recorder.WorkResponse.WorkResult.success, 0);
         assertWorkStateAndResultIs(pollReqs[1].req.getWorkLastIssued(), 100, Recorder.WorkResponse.WorkState.complete, Recorder.WorkResponse.WorkResult.success, 0);
@@ -453,23 +459,5 @@ public class WorkHandlingTest {
                 throw new RuntimeException(e);
             }
         };
-    }
-
-    public static void assertRecorderInfoAllGood(Recorder.RecorderInfo recorderInfo) {
-        assertThat(recorderInfo.getIp(), is("10.20.30.40"));
-        assertThat(recorderInfo.getHostname(), is("foo-host"));
-        assertThat(recorderInfo.getAppId(), is("bar-app"));
-        assertThat(recorderInfo.getInstanceGrp(), is("baz-grp"));
-        assertThat(recorderInfo.getCluster(), is("quux-cluster"));
-        assertThat(recorderInfo.getInstanceId(), is("corge-iid"));
-        assertThat(recorderInfo.getProcName(), is("grault-proc"));
-        assertThat(recorderInfo.getVmId(), is("garply-vmid"));
-        assertThat(recorderInfo.getZone(), is("waldo-zone"));
-        assertThat(recorderInfo.getInstanceType(), is("c0.small"));
-        DateTime dateTime = ISODateTimeFormat.dateTimeParser().parseDateTime(recorderInfo.getLocalTime());
-        DateTime now = DateTime.now();
-        assertThat(dateTime, allOf(greaterThan(now.minusMinutes(1)), lessThan(now.plusMinutes(1))));
-        assertThat(recorderInfo.getRecorderVersion(), is(1));
-        assertThat(recorderInfo.getRecorderUptime(), allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(60)));
     }
 }

--- a/e2etest/src/test/java/fk/prof/recorder/main/BurnHalfInHalfOut.java
+++ b/e2etest/src/test/java/fk/prof/recorder/main/BurnHalfInHalfOut.java
@@ -1,0 +1,49 @@
+package fk.prof.recorder.main;
+
+import fk.prof.PerfCtx;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @understands burning 50% and another 50% CPU across 2 branches, but covering 100%+Single and 50%+Duplicate respectively
+ */
+public class BurnHalfInHalfOut {
+    private static final int MULTIPLIER = 97;
+    @SuppressWarnings("WeakerAccess")
+    public static volatile long val = 0;
+    @SuppressWarnings("WeakerAccess")
+    public static volatile long outBurnTime = 0, inBurnTime = 0;
+
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void main(String[] args) {
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("outBurnTime = " + outBurnTime);
+                System.out.println("inBurnTime = " + inBurnTime);
+                System.out.println("val = " + val);
+            }
+        }));
+        BurnHalfInHalfOut burner = new BurnHalfInHalfOut();
+        for (int i = 0; ; i++) {
+            long l = System.currentTimeMillis();
+            burner.immolate(i);
+            val += System.currentTimeMillis() - l;
+        }
+    }
+
+    private final PerfCtx c100Ctx = new PerfCtx("c100", 100);
+
+    private void immolate(int i) {
+        long start = System.currentTimeMillis();
+        Blackhole.consumeCPU((i * MULTIPLIER) % 10000);
+        long start2 = System.currentTimeMillis();
+        outBurnTime += start2 - start;
+        try {
+            c100Ctx.begin();
+            Blackhole.consumeCPU((i * MULTIPLIER) % 10000);
+            inBurnTime += System.currentTimeMillis() - start2;
+        } finally {
+            c100Ctx.end();
+        }
+    }
+}

--- a/recorder/src/idl/recorder.proto
+++ b/recorder/src/idl/recorder.proto
@@ -48,7 +48,7 @@ message WorkResponse {
     failure = 2;
   }
   required WorkResult work_result = 3;
-  required uint32 elapsed_time = 5;
+  required uint32 elapsed_time = 4;
 }
 
 message WorkAssignment {

--- a/recorder/src/main/cpp/config.cc
+++ b/recorder/src/main/cpp/config.cc
@@ -94,6 +94,9 @@ void ConfigurationOptions::load(const char* options) {
             } else if (strstr(key, "metrics_dst_port") == key) {
                 metrics_dst_port = static_cast<std::uint16_t>(atoi(value));
                 if (metrics_dst_port == 0) metrics_dst_port = DEFAULT_METRICS_DEST_PORT;
+            } else if (strstr(key, "noctx_cov_pct") == key) {
+                noctx_cov_pct = static_cast<std::uint8_t>(atoi(value));
+                if (noctx_cov_pct > 100) noctx_cov_pct = 100;
             } else {
                 logger->warn("Unknown configuration option: {}", key);
             }

--- a/recorder/src/main/cpp/config.hh
+++ b/recorder/src/main/cpp/config.hh
@@ -43,6 +43,8 @@ struct ConfigurationOptions {
     spdlog::level::level_enum log_level;
     std::uint16_t metrics_dst_port;
 
+    std::uint8_t noctx_cov_pct;
+
     ConfigurationOptions(const char* options) :
         service_endpoint(nullptr),
         ip(nullptr),
@@ -56,7 +58,8 @@ struct ConfigurationOptions {
         inst_typ(nullptr),
         backoff_start(MIN_BACKOFF_START), backoff_multiplier(DEFAULT_BACKOFF_MULTIPLIER), backoff_max(DEFAULT_BACKOFF_MAX), max_retries(DEFAULT_MAX_RETRIES),
         poll_itvl(DEFAULT_POLLING_INTERVAL),
-        log_level(spdlog::level::info), metrics_dst_port(DEFAULT_METRICS_DEST_PORT) {
+        log_level(spdlog::level::info), metrics_dst_port(DEFAULT_METRICS_DEST_PORT),
+        noctx_cov_pct(0) {
         load(options);
     }
 

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -472,6 +472,10 @@ void Controller::retire_work(const std::uint64_t work_id) {
                 logger->warn("Stale work-retire call (target work_id was {}, current work_id is {}), ignoring", work_id, w.work_id());
                 return;//TODO: test me!
             }
+            if (wst == recording::WorkResponse::complete) {
+                logger->info("Work {} has already been retired (result: {}), ignoring stale retire call", work_id, wres);
+                return;
+            }
             logger->info("Will now retire work {}", work_id);
             for (auto i = 0; i < w.work_size(); i++) {
                 auto work = w.work(i);

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -532,7 +532,7 @@ void Controller::issue(const recording::CpuSampleWork& csw) {
     auto max_stack_depth = csw.max_frames();
     logger->info("Starting cpu-sampling at {} Hz and for upto {} frames", freq, max_stack_depth);
     
-    GlobalCtx::recording.cpu_profiler.reset(new Profiler(jvm, jvmti, thread_map, writer, max_stack_depth, freq));
+    GlobalCtx::recording.cpu_profiler.reset(new Profiler(jvm, jvmti, thread_map, writer, max_stack_depth, freq, *GlobalCtx::prob_pct, cfg.noctx_cov_pct));
     JNIEnv *env = getJNIEnv(jvm);
     GlobalCtx::recording.cpu_profiler->start(env);
 }

--- a/recorder/src/main/cpp/perf_ctx.cc
+++ b/recorder/src/main/cpp/perf_ctx.cc
@@ -125,6 +125,10 @@ int PerfCtx::ThreadTracker::current(PerfCtx::ThreadTracker::EffectiveCtx& curr) 
     return len;
 }
 
+bool PerfCtx::ThreadTracker::in_ctx() {
+    return effective.size() > 0;
+}
+
 bool PerfCtx::ThreadTracker::should_record() {
     return record;
 }

--- a/recorder/src/main/cpp/perf_ctx.cc
+++ b/recorder/src/main/cpp/perf_ctx.cc
@@ -355,12 +355,14 @@ JNIEXPORT void JNICALL Java_fk_prof_PerfCtx_end(JNIEnv* env, jobject self, jlong
     } catch (const PerfCtx::IncorrectEnterExitPairing& e) {
         env->ThrowNew(env->FindClass("fk/prof/IncorrectContextException"), e.what());
     }
+    thd_info->release();
 }
 
 JNIEXPORT void JNICALL Java_fk_prof_PerfCtx_begin(JNIEnv* env, jobject self, jlong ctx_id) {
     auto thd_info = get_thread_map().get(env);
     SPDLOG_TRACE(logger, "Begining perf-ctx {} for jniEnv: {}", ctx_id, reinterpret_cast<std::uint64_t>(env));
     thd_info->ctx_tracker.enter(static_cast<PerfCtx::TracePt>(ctx_id));
+    thd_info->release();
 }
 
 

--- a/recorder/src/main/cpp/perf_ctx.cc
+++ b/recorder/src/main/cpp/perf_ctx.cc
@@ -87,7 +87,6 @@ void PerfCtx::ThreadTracker::enter(PerfCtx::TracePt pt) {
         effective_end++;
         break;
     }
-
 }
 
 void PerfCtx::ThreadTracker::exit(PerfCtx::TracePt pt) throw (IncorrectEnterExitPairing) {

--- a/recorder/src/main/cpp/perf_ctx.hh
+++ b/recorder/src/main/cpp/perf_ctx.hh
@@ -155,6 +155,7 @@ namespace PerfCtx {
         void exit(TracePt pt) throw (IncorrectEnterExitPairing);
         int current(EffectiveCtx& curr);
         bool should_record();
+        bool in_ctx();
     };
 };
 

--- a/recorder/src/main/cpp/processor.cc
+++ b/recorder/src/main/cpp/processor.cc
@@ -20,12 +20,6 @@ void sleep_for_millis(uint period) {
 #endif
 }
 
-TRACE_DEFINE_BEGIN(Processor, kTraceProcessorTotal)
-    TRACE_DEFINE("start processor")
-    TRACE_DEFINE("stop processor")
-    TRACE_DEFINE("chech that processor is running")
-TRACE_DEFINE_END(Processor, kTraceProcessorTotal);
-
 #define METRIC_TYPE "cpu_samp_proc"
 
 Processor::Processor(jvmtiEnv* jvmti, CircularQueue& buffer, SignalHandler& handler, int interval)
@@ -77,19 +71,16 @@ void callbackToRunProcessor(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
 }
 
 void Processor::start(JNIEnv *jniEnv) {
-    TRACE(Processor, kTraceProcessorStart);
     isRunning_.store(true, std::memory_order_relaxed);
     thd_proc = start_new_thd(jniEnv, jvmti_, "Fk-Prof Processing Thread", callbackToRunProcessor, this);
 }
 
 void Processor::stop() {
-    TRACE(Processor, kTraceProcessorStop);
     isRunning_.store(false, std::memory_order_relaxed);
     await_thd_death(thd_proc);
     thd_proc.reset();
 }
 
 bool Processor::isRunning() const {
-    TRACE(Processor, kTraceProcessorRunning);
     return isRunning_.load(std::memory_order_relaxed);
 }

--- a/recorder/src/main/cpp/processor.hh
+++ b/recorder/src/main/cpp/processor.hh
@@ -6,16 +6,6 @@
 #include "signal_handler.hh"
 #include "circular_queue.hh"
 #include "ti_thd.hh"
-#include "trace.hh"
-
-const int kTraceProcessorTotal = 3;
-
-const int kTraceProcessorStart = 0;
-const int kTraceProcessorStop = 1;
-const int kTraceProcessorRunning = 2;
-
-TRACE_DECLARE(Processor, kTraceProcessorTotal);
-
 
 class Processor {
 

--- a/recorder/src/main/cpp/profile_writer.cc
+++ b/recorder/src/main/cpp/profile_writer.cc
@@ -104,6 +104,7 @@ void ProfileSerializingWriter::record(const JVMPI_CallTrace &trace, ThreadBucket
         } else {
             ss->set_thread_id(known_thd->second);
         }
+        info->release();
     } else {
         ss->set_error(translate_forte_error(trace.num_frames));
     }

--- a/recorder/src/main/cpp/profile_writer.cc
+++ b/recorder/src/main/cpp/profile_writer.cc
@@ -5,6 +5,8 @@
 
 //for buff, no one uses read-end here, so it is inconsistent
 
+#define NOCTX_ID 0
+
 void ProfileWriter::flush() {
     w->write_unbuffered(data.buff, data.write_end, 0); //TODO: err-check me!
     data.write_end = 0;
@@ -142,9 +144,12 @@ void ProfileSerializingWriter::record(const JVMPI_CallTrace &trace, ThreadBucket
     if (snipped) s_c_frame_snipped.inc();
     ss->set_snipped(snipped);
 
-    if (trace.num_frames < 0) {
+    if (trace.num_frames <= 0) {
         s_m_stack_sample_err.mark();
         return;
+    }
+    if (ctx_len == 0) {
+        ss->add_trace_id(NOCTX_ID);
     }
 
     for (auto i = 0; i < Util::min(static_cast<TruncationCap>(trace.num_frames), trunc_thresholds.cpu_samples_max_stack_sz); i++) {
@@ -201,8 +206,10 @@ void ProfileSerializingWriter::flush() {
 #define METRIC_TYPE "profile_serializer"
 
 ProfileSerializingWriter::ProfileSerializingWriter(jvmtiEnv* _jvmti, ProfileWriter& _w, SiteResolver::MethodInfoResolver _fir, SiteResolver::LineNoResolver _lnr,
-                                                   PerfCtx::Registry& _reg, const SerializationFlushThresholds& _sft, const TruncationThresholds& _trunc_thresholds) :
-    jvmti(_jvmti), w(_w), fir(_fir), lnr(_lnr), reg(_reg), next_mthd_id(10), next_thd_id(3), next_ctx_id(5), sft(_sft), cpu_samples_flush_ctr(0), trunc_thresholds(_trunc_thresholds),
+                                                   PerfCtx::Registry& _reg, const SerializationFlushThresholds& _sft, const TruncationThresholds& _trunc_thresholds,
+                                                   std::uint8_t _noctx_cov_pct) :
+    jvmti(_jvmti), w(_w), fir(_fir), lnr(_lnr), reg(_reg), next_mthd_id(10), next_thd_id(3), next_ctx_id(5), sft(_sft), cpu_samples_flush_ctr(0),
+    trunc_thresholds(_trunc_thresholds),
 
     s_c_new_thd_info(GlobalCtx::metrics_registry->new_counter({METRICS_DOMAIN, METRIC_TYPE, "thd_rpt", "new"})),
     s_c_new_ctx_info(GlobalCtx::metrics_registry->new_counter({METRICS_DOMAIN, METRIC_TYPE, "ctx_rpt", "new"})),
@@ -224,6 +231,14 @@ ProfileSerializingWriter::ProfileSerializingWriter(jvmtiEnv* _jvmti, ProfileWrit
     s_c_bad_lineno.clear();
 
     s_c_frame_snipped.clear();
+
+    auto idx_dat = cpu_sample_accumulator.mutable_indexed_data();
+    auto new_ctx = idx_dat->add_trace_ctx();
+    new_ctx->set_trace_id(NOCTX_ID);
+    new_ctx->set_is_generated(false);
+    new_ctx->set_coverage_pct(_noctx_cov_pct);
+    new_ctx->set_merge(recording::TraceContext_MergeSemantics::TraceContext_MergeSemantics_parent);
+    new_ctx->set_trace_name(NOCTX_NAME);
 }
 
 ProfileSerializingWriter::~ProfileSerializingWriter() {}

--- a/recorder/src/main/cpp/profile_writer.hh
+++ b/recorder/src/main/cpp/profile_writer.hh
@@ -11,6 +11,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#define NOCTX_NAME "~ OTHERS ~"
+
 class RawWriter {
 public:
     RawWriter() {}
@@ -110,7 +112,8 @@ private:
 
 public:
     ProfileSerializingWriter(jvmtiEnv* _jvmti, ProfileWriter& _w, SiteResolver::MethodInfoResolver _fir, SiteResolver::LineNoResolver _lnr,
-                             PerfCtx::Registry& _reg, const SerializationFlushThresholds& _sft, const TruncationThresholds& _trunc_thresholds);
+                             PerfCtx::Registry& _reg, const SerializationFlushThresholds& _sft, const TruncationThresholds& _trunc_thresholds,
+                             std::uint8_t _noctx_cov_pct);
 
     ~ProfileSerializingWriter();
 

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -3,19 +3,6 @@
 ASGCTType Asgct::asgct_;
 IsGCActiveType Asgct::is_gc_active_;
 
-TRACE_DEFINE_BEGIN(Profiler, kTraceProfilerTotal)
-    TRACE_DEFINE("start failed")
-    TRACE_DEFINE("start succeeded")
-    TRACE_DEFINE("set sampling interval failed")
-    TRACE_DEFINE("set sampling interval succeeded")
-    TRACE_DEFINE("set stack frames to capture failed")
-    TRACE_DEFINE("set stack frames to capture succeeded")
-    TRACE_DEFINE("set new file failed")
-    TRACE_DEFINE("set new file succeeded")
-    TRACE_DEFINE("stop failed")
-    TRACE_DEFINE("stop succeeded")
-TRACE_DEFINE_END(Profiler, kTraceProfilerTotal);
-
 static void handle_profiling_signal(int signum, siginfo_t *info, void *context) {
     std::shared_ptr<Profiler> cpu_profiler = GlobalCtx::recording.cpu_profiler;
     if (cpu_profiler.get() == nullptr) {
@@ -76,12 +63,10 @@ bool Profiler::start(JNIEnv *jniEnv) {
     /* within critical section */
 
     if (__is_running()) {
-        TRACE(Profiler, kTraceProfilerStartFailed);
         logError("WARN: Start called but sampling is already running\n");
         return true;
     }
 
-    TRACE(Profiler, kTraceProfilerStartOk);
 
     // reference back to Profiler::handle on the singleton
     // instance of Profiler
@@ -96,7 +81,6 @@ void Profiler::stop() {
     SimpleSpinLockGuard<true> guard(ongoing_conf);
 
     if (!__is_running()) {
-        TRACE(Profiler, kTraceProfilerStopFailed);
         return;
     }
 

--- a/recorder/src/main/cpp/profiler.hh
+++ b/recorder/src/main/cpp/profiler.hh
@@ -52,7 +52,7 @@ public:
 
 class Profiler {
 public:
-    explicit Profiler(JavaVM *_jvm, jvmtiEnv *_jvmti, ThreadMap &_thread_map, std::shared_ptr<ProfileWriter> _writer, std::uint32_t _max_stack_depth, std::uint32_t _sampling_freq);
+    explicit Profiler(JavaVM *_jvm, jvmtiEnv *_jvmti, ThreadMap &_thread_map, std::shared_ptr<ProfileWriter> _writer, std::uint32_t _max_stack_depth, std::uint32_t _sampling_freq, ProbPct& _prob_pct, std::uint8_t _noctx_cov_pct);
 
     bool start(JNIEnv *jniEnv);
 
@@ -87,6 +87,10 @@ private:
 
     // indicates change of internal state
     std::atomic<bool> ongoing_conf;
+
+    ProbPct& prob_pct;
+    std::atomic<std::uint32_t> sampling_attempts;
+    const std::uint8_t noctx_cov_pct;
 
     metrics::Ctr& s_c_cpu_samp_total;
     metrics::Ctr& s_c_cpu_samp_err_no_jni;

--- a/recorder/src/main/cpp/profiler.hh
+++ b/recorder/src/main/cpp/profiler.hh
@@ -20,23 +20,6 @@ using std::ofstream;
 using std::ostringstream;
 using std::string;
 
-#include "trace.hh"
-
-const int kTraceProfilerTotal = 10;
-
-const int kTraceProfilerStartFailed = 0;
-const int kTraceProfilerStartOk = 1;
-const int kTraceProfilerSetIntervalFailed = 2;
-const int kTraceProfilerSetIntervalOk = 3;
-const int kTraceProfilerSetFramesFailed = 4;
-const int kTraceProfilerSetFramesOk = 5;
-const int kTraceProfilerSetFileFailed = 6;
-const int kTraceProfilerSetFileOk = 7;
-const int kTraceProfilerStopFailed = 8;
-const int kTraceProfilerStopOk = 9;
-
-TRACE_DECLARE(Profiler, kTraceProfilerTotal);
-
 template <bool blocking = true>
 class SimpleSpinLockGuard {
 private:

--- a/recorder/src/test/cpp/test_config.cc
+++ b/recorder/src/test/cpp/test_config.cc
@@ -25,7 +25,8 @@ TEST(ParsesAllOptions) {
                     "backoff_max=15,"
                     "log_lvl=warn,"
                     "poll_itvl=30,"
-                    "metrics_dst_port=10203");
+                    "metrics_dst_port=10203,"
+                    "noctx_cov_pct=25");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -46,6 +47,7 @@ TEST(ParsesAllOptions) {
     CHECK_EQUAL(spdlog::level::warn, options.log_level);
     CHECK_EQUAL(30, options.poll_itvl);
     CHECK_EQUAL(10203, options.metrics_dst_port);
+    CHECK_EQUAL(25, options.noctx_cov_pct);
 }
 
 TEST(DefaultAppropriately) {
@@ -81,6 +83,7 @@ TEST(DefaultAppropriately) {
     CHECK_EQUAL(spdlog::level::info, options.log_level);
     CHECK_EQUAL(60, options.poll_itvl);
     CHECK_EQUAL(11514, options.metrics_dst_port);
+    CHECK_EQUAL(0, options.noctx_cov_pct);
 }
 
 TEST(SafelyTerminatesStrings) {

--- a/recorder/src/test/cpp/test_jni.hh
+++ b/recorder/src/test/cpp/test_jni.hh
@@ -87,6 +87,14 @@ JNIEXPORT jint JNICALL Java_fk_prof_TestJni_getCtxMergeSemantic
 JNIEXPORT jboolean JNICALL Java_fk_prof_TestJni_isGenerated
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     fk_prof_TestJni
+ * Method:    getNoCtxName
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_fk_prof_TestJni_getNoCtxName
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/recorder/src/test/cpp/test_perf_ctx_tracker.cc
+++ b/recorder/src/test/cpp/test_perf_ctx_tracker.cc
@@ -22,6 +22,12 @@ PerfCtx::TracePt reg(Registry& r, const char* name, PerfCtx::MergeSemantic m = P
     return r.find_or_bind(name, 0, static_cast<std::uint8_t>(m));
 }
 
+#define LOAD_AND_ASSERT_CURRENT_CTX_IS(expected_len, ctx, into)  \
+    {                                                            \
+        CHECK_EQUAL(expected_len, ctx.current(into));            \
+        CHECK_EQUAL((expected_len > 0), ctx.in_ctx());           \
+    }
+
 TEST(ThreadPerfCtxTracker__should_understand_ctx__when_merging_to_parent) {
     TestEnv _;
     Registry r;
@@ -30,25 +36,25 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_merging_to_parent) {
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(10);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{10}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.enter(20);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.enter(30);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(30);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(20);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(10);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_not_allow_unpaired_pop) {
@@ -58,7 +64,7 @@ TEST(ThreadPerfCtxTracker__should_not_allow_unpaired_pop) {
     ThreadTracker t_ctx(r, prob_pct, 210);
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(10);
     t_ctx.enter(20);
     try {
@@ -68,12 +74,12 @@ TEST(ThreadPerfCtxTracker__should_not_allow_unpaired_pop) {
         CHECK_EQUAL("Expected 20 got 10", e.what());
     }
     std::array<TracePt, 1> expected{{10}};
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(20);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(10);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_ctx__when_scoping_under_parent) {
@@ -90,68 +96,68 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_scoping_under_parent) {
     reg(r, "3");
     reg(r, "5");
     reg(r, "7");
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3) << GENERATED_COMBINATION_SHIFT) | 0x5;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     //now we exit 2 nearest scopes and push them in opposite order
     
     t_ctx.exit(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 3) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 3 * 5) << GENERATED_COMBINATION_SHIFT) | 0x4;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     //permutation id now is 4 and not 5, while combination-id is the same (this distinguishes 2>7>3>5 from 2>7>5>3
 
     t_ctx.exit(SCOPED_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 3) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 7);
     expected[0] = 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__not_nest_beyond_max_depth__when_scoping_under_parent) {
@@ -171,48 +177,48 @@ TEST(ThreadPerfCtxTracker__not_nest_beyond_max_depth__when_scoping_under_parent)
     reg(r, "11");
     reg(r, "13");
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     
     t_ctx.enter(SCOPED_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3) << GENERATED_COMBINATION_SHIFT) | 0x5;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 11);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3 * 11) << GENERATED_COMBINATION_SHIFT) | 0xE;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 13);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3 * 11) << GENERATED_COMBINATION_SHIFT) | 0xE;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 17);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3 * 11) << GENERATED_COMBINATION_SHIFT) | 0xE;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
 
     t_ctx.exit(42); //this is gibberish, doesn't matter, because ctx-tracer is ignoring it (its beyond 5 levels)
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     t_ctx.exit(42); //gibberish again, same as above
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     try {
@@ -224,26 +230,26 @@ TEST(ThreadPerfCtxTracker__not_nest_beyond_max_depth__when_scoping_under_parent)
     
     t_ctx.exit(SCOPED_MASK | 11);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 3) << GENERATED_COMBINATION_SHIFT) | 0x5;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 7);
     expected[0] = 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__not_exceed_max_depth_due_to_recursion___when_scoping_under_parent) {
@@ -263,74 +269,74 @@ TEST(ThreadPerfCtxTracker__not_exceed_max_depth_due_to_recursion___when_scoping_
     reg(r, "11");
     reg(r, "13");
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 11);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11) << GENERATED_COMBINATION_SHIFT);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.enter(SCOPED_MASK | 5);
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     t_ctx.enter(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11 * 5 * 3) << GENERATED_COMBINATION_SHIFT) | 0x5;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 7);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11 * 5 * 3 * 7) << GENERATED_COMBINATION_SHIFT) | 0x14;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 13);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(1729);//gibberish
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 7);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11 * 5 * 3) << GENERATED_COMBINATION_SHIFT) | 0x5;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 3);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.exit(SCOPED_MASK | 5);
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     t_ctx.exit(SCOPED_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 11) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 11);
     expected[0] = 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_track_recursion__and_handle_scoping_well__when_strict_scoping_under_parent__and_starting_out_with_scoped_ctx) {
@@ -349,66 +355,66 @@ TEST(ThreadPerfCtxTracker__should_track_recursion__and_handle_scoping_well__when
     reg(r, "5", PerfCtx::MergeSemantic::scoped_strict);
     reg(r, "7");
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(SCOPED_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{SCOPED_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_STRICT_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_STRICT_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 5) << GENERATED_COMBINATION_SHIFT) | 0x4;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     
     t_ctx.enter(SCOPED_STRICT_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 5 * 5) << GENERATED_COMBINATION_SHIFT) | 0x12;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.enter(100 - 1);//gibberish
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.exit(i);//gibberish
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     t_ctx.exit(SCOPED_STRICT_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5 * 5) << GENERATED_COMBINATION_SHIFT) | 0x4;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_STRICT_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7 * 5) << GENERATED_COMBINATION_SHIFT) | 0x1;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_STRICT_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 7);
     expected[0] = SCOPED_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_ctx__when_stacking_over_parent_____and_handle_overflow_well) {
@@ -423,66 +429,66 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_stacking_over_parent_____
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(PARENT_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{PARENT_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(STACK_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(PARENT_MASK | 4);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(STACK_MASK | 9);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 9;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
     
     t_ctx.enter(STACK_MASK | 5);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 5;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.enter(100 - 1);//gibberish
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.exit(i);//gibberish
-        CHECK_EQUAL(1, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 1);
     }
 
     t_ctx.exit(STACK_MASK | 5);
     expected[0] = STACK_MASK | 9;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(STACK_MASK | 9);
     expected[0] = STACK_MASK | 7;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 4);
     expected[0] = STACK_MASK | 7;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(STACK_MASK | 7);
     expected[0] = PARENT_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_handle_stacking_merge_semantic_for_first_ctx) {
@@ -497,34 +503,34 @@ TEST(ThreadPerfCtxTracker__should_handle_stacking_merge_semantic_for_first_ctx) 
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(STACK_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, 1> expected{{STACK_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(STACK_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(PARENT_MASK | 4);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACK_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 4);
     expected[0] = STACK_MASK | 7;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(STACK_MASK | 7);
     expected[0] = STACK_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(STACK_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_ctx__when_duplicating_over_parent_____and_handle_overflow_well) {
@@ -538,33 +544,33 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_duplicating_over_parent__
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(PARENT_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, MAX_NESTING> expected{{PARENT_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(DUP_MASK | 7);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.enter(PARENT_MASK | 4);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.enter(DUP_MASK | 9);
-    CHECK_EQUAL(3, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(3, t_ctx, curr);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
     expected[2] = DUP_MASK | 9;
     CHECK_ARRAY_EQUAL(expected, curr, 3);
     
     t_ctx.enter(DUP_MASK | 5);
-    CHECK_EQUAL(4, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(4, t_ctx, curr);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
     expected[2] = DUP_MASK | 9;
@@ -573,13 +579,13 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_duplicating_over_parent__
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.enter(100 - 1);//gibberish
-        CHECK_EQUAL(4, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(4, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 4);
     }
 
     for (auto i = 0; i < 100; i++) {
         t_ctx.exit(i);//gibberish
-        CHECK_EQUAL(4, t_ctx.current(curr));
+        LOAD_AND_ASSERT_CURRENT_CTX_IS(4, t_ctx, curr);
         CHECK_ARRAY_EQUAL(expected, curr, 4);
     }
 
@@ -587,28 +593,28 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__when_duplicating_over_parent__
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
     expected[2] = DUP_MASK | 9;
-    CHECK_EQUAL(3, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(3, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 3);
 
     t_ctx.exit(DUP_MASK | 9);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(PARENT_MASK | 4);
     expected[0] = PARENT_MASK | 2;
     expected[1] = DUP_MASK | 7;
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(DUP_MASK | 7);
     expected[0] = PARENT_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_merge_for_first_ctx) {
@@ -622,20 +628,20 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_merge_for_first
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(DUP_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, MAX_NESTING> expected{{DUP_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(DUP_MASK | 7);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = DUP_MASK | 2;
     expected[1] = DUP_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.enter(PARENT_MASK | 4);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = DUP_MASK | 2;
     expected[1] = DUP_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
@@ -643,16 +649,16 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_merge_for_first
     t_ctx.exit(PARENT_MASK | 4);
     expected[0] = DUP_MASK | 2;
     expected[1] = DUP_MASK | 7;
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(DUP_MASK | 7);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(DUP_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_chain_broken_by_scoping_elements) {
@@ -674,25 +680,25 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_chain_broken_by
     reg(r, "13");
 
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(DUP_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, MAX_NESTING> expected{{DUP_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(SCOPED_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(DUP_MASK | 5);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     expected[1] = DUP_MASK | 5;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.enter(DUP_MASK | 11);
-    CHECK_EQUAL(3, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(3, t_ctx, curr);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     expected[1] = DUP_MASK | 5;
     expected[2] = DUP_MASK | 11;
@@ -702,21 +708,21 @@ TEST(ThreadPerfCtxTracker__should_understand_ctx__with_duplicate_chain_broken_by
     t_ctx.exit(DUP_MASK | 11);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
     expected[1] = DUP_MASK | 5;
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(DUP_MASK | 5);
     expected[0] = MERGE_GENERATED_TYPE | ((2 * 7) << GENERATED_COMBINATION_SHIFT);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(SCOPED_MASK | 7);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(DUP_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_understand_duplicating_ctx__with_duplicate_chain_broken_by_stacking_elements) {
@@ -730,25 +736,25 @@ TEST(ThreadPerfCtxTracker__should_understand_duplicating_ctx__with_duplicate_cha
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(DUP_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, MAX_NESTING> expected{{DUP_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(STACKED_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = STACKED_MASK | 7;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(DUP_MASK | 4);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = STACKED_MASK | 7;
     expected[1] = DUP_MASK | 4;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.enter(DUP_MASK | 9);
-    CHECK_EQUAL(3, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(3, t_ctx, curr);
     expected[0] = STACKED_MASK | 7;
     expected[1] = DUP_MASK | 4;
     expected[2] = DUP_MASK | 9;
@@ -757,21 +763,21 @@ TEST(ThreadPerfCtxTracker__should_understand_duplicating_ctx__with_duplicate_cha
     t_ctx.exit(DUP_MASK | 9);
     expected[0] = STACKED_MASK | 7;
     expected[1] = DUP_MASK | 4;
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(DUP_MASK | 4);
     expected[0] = STACKED_MASK | 7;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(STACKED_MASK | 7);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(DUP_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_duplicating__when_chain_has_several_parent_merge_elements_between_2_duplicate) {
@@ -785,45 +791,45 @@ TEST(ThreadPerfCtxTracker__should_duplicating__when_chain_has_several_parent_mer
 
     std::array<TracePt, MAX_NESTING> curr;
 
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
     t_ctx.enter(DUP_MASK | 2);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     std::array<TracePt, MAX_NESTING> expected{{DUP_MASK | 2}};
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(PARENT_MASK | 7);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = DUP_MASK | 2;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(PARENT_MASK | 4);
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     expected[0] = DUP_MASK | 2;
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.enter(DUP_MASK | 9);
-    CHECK_EQUAL(2, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(2, t_ctx, curr);
     expected[0] = DUP_MASK | 2;
     expected[1] = DUP_MASK | 9;
     CHECK_ARRAY_EQUAL(expected, curr, 2);
 
     t_ctx.exit(DUP_MASK | 9);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 4);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(PARENT_MASK | 7);
     expected[0] = DUP_MASK | 2;
-    CHECK_EQUAL(1, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(1, t_ctx, curr);
     CHECK_ARRAY_EQUAL(expected, curr, 1);
 
     t_ctx.exit(DUP_MASK | 2);
-    CHECK_EQUAL(0, t_ctx.current(curr));
+    LOAD_AND_ASSERT_CURRENT_CTX_IS(0, t_ctx, curr);
 }
 
 TEST(ThreadPerfCtxTracker__should_turn_on_recording_enough_times_to_meet_desired_coverage) {

--- a/recorder/src/test/java/fk/prof/PerfCtxUnitTest.java
+++ b/recorder/src/test/java/fk/prof/PerfCtxUnitTest.java
@@ -152,6 +152,31 @@ public class PerfCtxUnitTest {
     }
 
     @Test
+    public void shouldNotAllowContext_withNameSimilarTo_NOCTX_NAME() {
+        String noCtxName = testJni.getNoCtxName();
+        try {
+            new PerfCtx(noCtxName);
+            fail("Should not allow creation of perf-ctx with noctx-name");
+        } catch (IllegalArgumentException e) {
+            //ignore
+        }
+
+        try {
+            new PerfCtx(noCtxName.substring(0, noCtxName.length() / 2));
+            fail("Should not allow creation of perf-ctx with first 1/2 of noctx-name");
+        } catch (IllegalArgumentException e) {
+            //ignore
+        }
+
+        try {
+            new PerfCtx(noCtxName.substring(noCtxName.length() / 2));
+            fail("Should not allow creation of perf-ctx with last 1/2 of noctx-name");
+        } catch (IllegalArgumentException e) {
+            //ignore
+        }
+    }
+
+    @Test
     public void shouldTrackContext_whenUsedIn_TryWithResources_Style() {
         //testJni.getAndStubCtxIdStart(105);
         PerfCtx ctx = new PerfCtx("foo bar baz", 25);

--- a/recorder/src/test/java/fk/prof/TestJni.java
+++ b/recorder/src/test/java/fk/prof/TestJni.java
@@ -27,4 +27,5 @@ public class TestJni {
     public native int getCtxCov(long ctxid);
     public native int getCtxMergeSemantic(long ctxid);
     public native boolean isGenerated(long ctxid);
+    public native String getNoCtxName();
 }


### PR DESCRIPTION
- *no-ctx* recording
- recorder-tick impl
- HTTP POST (over PUT) for backend bound RPC
- a thread-info object leak issue is fixed
- some junk tracer-code is removed

This PR needs to be merged after https://github.com/Flipkart/fk-prof/pull/66 because that PR covers metrics changes.

This PR was meant for lots of small fixes (turns out no-ctx change wasn't that small, in the end), but original intent was to amortize review overhead with all small changes in one PR.

We need to merge this (despite all open issues not being addressed by this), because we need recorder-tick for e2e test work.