### PR TITLE
Recorder dead backend bugfix

### DIFF
--- a/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import java.util.zip.Adler32;
 
 import static fk.prof.recorder.AssociationTest.rc;
+import static fk.prof.recorder.utils.Matchers.approximately;
 import static fk.prof.recorder.utils.Matchers.approximatelyBetween;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -55,9 +56,7 @@ public class WorkHandlingTest {
             "backoff_start=2," +
             "backoff_max=5," +
             "poll_itvl=1," +
-            "log_lvl=trace," +
-            "tx_ring_sz=10," +
-            "slow_tx_tolerance=1.01";
+            "log_lvl=trace";
     private TestBackendServer server;
     private Function<byte[], byte[]>[] association = new Function[2];
     private Function<byte[], byte[]>[] poll = new Function[18];
@@ -339,6 +338,7 @@ public class WorkHandlingTest {
             return null;
         };
 
+        setRunner(DEFAULT_ARGS + ",tx_ring_sz=10,slow_tx_tolerance=1.01");
         runner.start();
 
         assocAction[0].get(4, TimeUnit.SECONDS);
@@ -484,7 +484,7 @@ public class WorkHandlingTest {
         assertThat(ctx, workLastIssued.getWorkId(), is(expectedId));
         assertThat(ctx, workLastIssued.getWorkResult(), is(result));
         assertThat(ctx, workLastIssued.getWorkState(), is(state));
-        assertThat(ctx, workLastIssued.getElapsedTime(), is(elapsedTime));
+        assertThat(ctx, (long) workLastIssued.getElapsedTime(), approximately(elapsedTime, 1));
     }
 
     public static void assertWorkStateAndResultIs(Recorder.WorkResponse workLastIssued, long expectedId, final Recorder.WorkResponse.WorkState state, final Recorder.WorkResponse.WorkResult result, final int elapsedTime) {

--- a/recorder/src/main/cpp/config.cc
+++ b/recorder/src/main/cpp/config.cc
@@ -72,7 +72,9 @@ std::ostream& operator<<(std::ostream& os, const ConfigurationOptions* config) {
     PRINT_FIELD(metrics_dst_port, false);
     PRINT_FIELD_VALUE(noctx_cov_pct, static_cast<int>(config->noctx_cov_pct), false);
     PRINT_FIELD(allow_sigprof, false);
-    PRINT_FIELD(pctx_jar_path, true);
+    PRINT_FIELD(pctx_jar_path, false);
+    PRINT_FIELD(rpc_timeout, false);
+    PRINT_FIELD(slow_tx_tolerance, true);
     os << " }";
     return os;
 }
@@ -141,6 +143,10 @@ void ConfigurationOptions::load(const char* options) {
                     ((value[0] == 'y') || (value[0] == 'Y'));
             } else if (strstr(key, "pctx_jar_path") == key) {
                 pctx_jar_path = safe_copy_string(value, next);
+            } else if (strstr(key, "rpc_timeout") == key) {
+                rpc_timeout = static_cast<std::uint32_t>(atoi(value));
+            } else if (strstr(key, "slow_tx_tolerance") == key) {
+                slow_tx_tolerance = atof(value);
             } else {
                 logger->warn("Unknown configuration option: {}", key);
             }

--- a/recorder/src/main/cpp/config.cc
+++ b/recorder/src/main/cpp/config.cc
@@ -204,6 +204,7 @@ ConfigurationOptions::~ConfigurationOptions()  {
     safe_free_string(app_id);
     safe_free_string(inst_grp);
     safe_free_string(cluster);
+    safe_free_string(inst_id);
     safe_free_string(proc);
     safe_free_string(vm_id);
     safe_free_string(zone);

--- a/recorder/src/main/cpp/config.hh
+++ b/recorder/src/main/cpp/config.hh
@@ -51,6 +51,7 @@ struct ConfigurationOptions {
 
     std::uint32_t rpc_timeout;
     double slow_tx_tolerance;
+    std::uint32_t tx_ring_sz;
 
     ConfigurationOptions(const char* options) :
         service_endpoint(nullptr),
@@ -70,7 +71,8 @@ struct ConfigurationOptions {
         allow_sigprof(true),
         pctx_jar_path(nullptr),
         rpc_timeout(10),
-        slow_tx_tolerance(1.5) {
+        slow_tx_tolerance(1.5),
+        tx_ring_sz(1024 * 1024) {
 
         load(options);
     }

--- a/recorder/src/main/cpp/config.hh
+++ b/recorder/src/main/cpp/config.hh
@@ -49,6 +49,9 @@ struct ConfigurationOptions {
 
     char* pctx_jar_path;
 
+    std::uint32_t rpc_timeout;
+    double slow_tx_tolerance;
+
     ConfigurationOptions(const char* options) :
         service_endpoint(nullptr),
         ip(nullptr),
@@ -65,7 +68,9 @@ struct ConfigurationOptions {
         log_level(spdlog::level::info), metrics_dst_port(DEFAULT_METRICS_DEST_PORT),
         noctx_cov_pct(0),
         allow_sigprof(true),
-        pctx_jar_path(nullptr) {
+        pctx_jar_path(nullptr),
+        rpc_timeout(10),
+        slow_tx_tolerance(1.5) {
 
         load(options);
     }

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -192,6 +192,7 @@ void Controller::run_with_associate(const Buff& associate_response_buff, const T
     curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, write_to_curl_request);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &recv);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, read_from_curl_response);
+    curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT, cfg.rpc_timeout);
     
     std::function<void()> poll_cb;
 
@@ -259,6 +260,7 @@ void Controller::run() {
     curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, write_to_curl_request);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &recv);
     curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, read_from_curl_response);
+    curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT, cfg.rpc_timeout);
     
     while (keep_running.load(std::memory_order_relaxed)) {
         logger->info("Calling service-endpoint {} for associate resolution", service_endpoint_url);
@@ -366,6 +368,8 @@ private:
 
     std::function<void()> cancellation_fn;
 
+    std::uint32_t tx_timeout;
+
     ThdProcP thd_proc;
 
     metrics::Timer& s_t_rpc;
@@ -376,8 +380,8 @@ private:
 
 public:
     HttpRawProfileWriter(JavaVM *jvm, jvmtiEnv *jvmti, const std::string& _host, const std::uint32_t _port,
-                         BlockingRingBuffer& _ring, std::function<void()>&& _cancellation_fn) :
-        RawWriter(), host(_host), port(_port), ring(_ring), cancellation_fn(_cancellation_fn),
+                         BlockingRingBuffer& _ring, std::function<void()>&& _cancellation_fn, const std::uint32_t _tx_timeout) :
+        RawWriter(), host(_host), port(_port), ring(_ring), cancellation_fn(_cancellation_fn), tx_timeout(_tx_timeout),
 
         s_t_rpc(GlobalCtx::metrics_registry->new_timer({METRICS_DOMAIN, METRICS_TYPE_RPC, "profile"})),
         s_c_rpc_failures(GlobalCtx::metrics_registry->new_counter({METRICS_DOMAIN, METRICS_TYPE_RPC, "profile", "failures"})),
@@ -418,11 +422,14 @@ public:
 
         curl_easy_setopt(curl.get(), CURLOPT_READDATA, &rd_ctx);
         curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, ring_to_curl);
+        curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT, tx_timeout);
 
         if (do_call(curl, url.c_str(), "send-profile", 0, s_t_rpc, s_c_rpc_failures)) {
             logger->info("Profile posted successfully!");
         } else {
             logger->error("Couldn't post profile, http request failed, cancelling work.");
+            ring.readonly(); //because now there is no point in reading/writing anything anyway, also...
+            // ...this prevents race where processor wants to write more but raw-writer can't read any more
             cancellation_fn();
         }
     }
@@ -454,7 +461,8 @@ void Controller::issue_work(const std::string& host, const std::uint32_t port, s
                             });
                     };
                     if (w.work_size() > 0) {
-                        std::shared_ptr<HttpRawProfileWriter> raw_writer(new HttpRawProfileWriter(jvm, jvmti, host, port, raw_writer_ring, std::move(cancellation_cb)));
+                        std::uint32_t tx_timeout = cfg.slow_tx_tolerance * w.duration();
+                        std::shared_ptr<HttpRawProfileWriter> raw_writer(new HttpRawProfileWriter(jvm, jvmti, host, port, raw_writer_ring, std::move(cancellation_cb), tx_timeout));
                         writer.reset(new ProfileWriter(raw_writer, buff));
                         recording::RecordingHeader rh;
                         populate_recording_header(rh, w, controller_id, controller_version);

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -11,6 +11,7 @@ void controllerRunnable(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg) {
 
 Controller::Controller(JavaVM *_jvm, jvmtiEnv *_jvmti, ThreadMap& _thread_map, ConfigurationOptions& _cfg) :
     jvm(_jvm), jvmti(_jvmti), thread_map(_thread_map), cfg(_cfg), keep_running(false), writer(nullptr),
+    serializer(nullptr), processor(nullptr), raw_writer_ring(_cfg.tx_ring_sz),
 
     s_t_poll_rpc(GlobalCtx::metrics_registry->new_timer({METRICS_DOMAIN, METRICS_TYPE_RPC, "poll"})),
     s_c_poll_rpc_failures(GlobalCtx::metrics_registry->new_counter({METRICS_DOMAIN, METRICS_TYPE_RPC, "poll", "failures"})),

--- a/recorder/src/test/cpp/test_blocking_ring_buffer.cc
+++ b/recorder/src/test/cpp/test_blocking_ring_buffer.cc
@@ -506,11 +506,11 @@ TEST(BlockingRingBuffer_should_not_block_reads____or_allow_writes____when_readon
 
     start = std::chrono::steady_clock::now();
     CHECK_EQUAL(0, ring.read(buff, 0, 20));
-    CHECK_CLOSE(2, std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count(), 2);
+    CHECK_CLOSE(1, std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count(), 1);
 
     start = std::chrono::steady_clock::now();
     CHECK_EQUAL(0, ring.write(buff, 0, 20));
-    CHECK_CLOSE(8, std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count(), 3);
+    CHECK_CLOSE(1, std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count(), 1);
 }
 
 TEST(BlockingRingBuffer_should_not_block_writes____when_readonly____but_should_allow_completion_of_read) {

--- a/recorder/src/test/cpp/test_config.cc
+++ b/recorder/src/test/cpp/test_config.cc
@@ -28,7 +28,9 @@ TEST(ParsesAllOptions) {
                     "metrics_dst_port=10203,"
                     "noctx_cov_pct=25,"
                     "allow_sigprof=n,"
-                    "pctx_jar_path=/tmp/foo.jar");
+                    "pctx_jar_path=/tmp/foo.jar,"
+                    "rpc_timeout=7,"
+                    "slow_tx_tolerance=1.25");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -52,6 +54,8 @@ TEST(ParsesAllOptions) {
     CHECK_EQUAL(25, options.noctx_cov_pct);
     CHECK_EQUAL(false, options.allow_sigprof);
     CHECK_EQUAL("/tmp/foo.jar", options.pctx_jar_path);
+    CHECK_EQUAL(7, options.rpc_timeout);
+    CHECK_EQUAL(1.25, options.slow_tx_tolerance);
     CHECK_EQUAL(true, options.valid());
 
 }
@@ -141,6 +145,8 @@ TEST(DefaultAppropriately) {
     CHECK_EQUAL(11514, options.metrics_dst_port);
     CHECK_EQUAL(0, options.noctx_cov_pct);
     CHECK_EQUAL(true, options.allow_sigprof);
+    CHECK_EQUAL(10, options.rpc_timeout);
+    CHECK_EQUAL(1.5, options.slow_tx_tolerance);
     CHECK_EQUAL(true, options.valid());
 }
 

--- a/recorder/src/test/cpp/test_config.cc
+++ b/recorder/src/test/cpp/test_config.cc
@@ -30,7 +30,8 @@ TEST(ParsesAllOptions) {
                     "allow_sigprof=n,"
                     "pctx_jar_path=/tmp/foo.jar,"
                     "rpc_timeout=7,"
-                    "slow_tx_tolerance=1.25");
+                    "slow_tx_tolerance=1.25,"
+                    "tx_ring_sz=102400");
     
     ConfigurationOptions options(str.c_str());
     CHECK_EQUAL("http://10.20.30.40:9070", options.service_endpoint);
@@ -56,6 +57,7 @@ TEST(ParsesAllOptions) {
     CHECK_EQUAL("/tmp/foo.jar", options.pctx_jar_path);
     CHECK_EQUAL(7, options.rpc_timeout);
     CHECK_EQUAL(1.25, options.slow_tx_tolerance);
+    CHECK_EQUAL(102400, options.tx_ring_sz);
     CHECK_EQUAL(true, options.valid());
 
 }
@@ -147,6 +149,7 @@ TEST(DefaultAppropriately) {
     CHECK_EQUAL(true, options.allow_sigprof);
     CHECK_EQUAL(10, options.rpc_timeout);
     CHECK_EQUAL(1.5, options.slow_tx_tolerance);
+    CHECK_EQUAL(1024 * 1024, options.tx_ring_sz);
     CHECK_EQUAL(true, options.valid());
 }
 
@@ -163,6 +166,23 @@ TEST(DefaultAppropriately) {
         auto str = ss.str();                           \
         ConfigurationOptions opts(str.c_str());        \
         CHECK_EQUAL(false, opts.valid());              \
+    }
+
+#define ASSERT_INVALID_WITH_VALUE(str_vec, key, value)  \
+    {                                                   \
+        std::stringstream ss;                           \
+        bool first = true;                              \
+        for (const auto& opt : str_vec) {               \
+            if (! first) ss << ",";                     \
+            first = false;                              \
+            if (opt.find(key) == 0) {                   \
+                ss << key << "=" << value;              \
+            };                                          \
+            ss << opt;                                  \
+        }                                               \
+        auto str = ss.str();                            \
+        ConfigurationOptions opts(str.c_str());         \
+        CHECK_EQUAL(false, opts.valid());               \
     }
 
 TEST(Validity) {
@@ -186,7 +206,10 @@ TEST(Validity) {
             "poll_itvl=30",
             "metrics_dst_port=10203",
             "noctx_cov_pct=25",
-            "pctx_jar_path=/tmp/foo.jar"};
+            "pctx_jar_path=/tmp/foo.jar",
+            "rpc_timeout=10",
+            "slow_tx_tolerance=1.2",
+            "tx_ring_sz=102400"};
 
     ASSERT_INVALID_WITHOUT(opts, "service_endpoint");
     ASSERT_INVALID_WITHOUT(opts, "ip");
@@ -200,6 +223,9 @@ TEST(Validity) {
     ASSERT_INVALID_WITHOUT(opts, "zone");
     ASSERT_INVALID_WITHOUT(opts, "inst_typ");
     ASSERT_INVALID_WITHOUT(opts, "pctx_jar_path");
+    ASSERT_INVALID_WITH_VALUE(opts, "rpc_timeout", 0);
+    ASSERT_INVALID_WITH_VALUE(opts, "slow_tx_tolerance", 0.99);
+    ASSERT_INVALID_WITH_VALUE(opts, "tx_ring_sz", 0);
 }
 
 


### PR DESCRIPTION
This fixes the bug that lead to recorder being blocked on one of the test-boxes when backends suddenly disappeared.