### PR TITLE
Signal hdlr reentrance

### DIFF
--- a/recorder/CMakeLists.txt
+++ b/recorder/CMakeLists.txt
@@ -144,7 +144,8 @@ set(SOURCE_FILES
     ${SRC}/prob_pct.hh
     ${SRC}/prob_pct.cc
     ${SRC}/metric_formatter.hh
-    ${SRC}/metric_formatter.cc)
+    ${SRC}/metric_formatter.cc
+    ${SRC}/unique_readsafe_ptr.hh)
 
 set(TI_SRC_FILES
     ${SRC}/agent.cc)
@@ -166,6 +167,7 @@ set(TEST_FILES
     ${SRC_TEST}/test_prob_pct.cc
     ${SRC_TEST}/test_blocking_ring_buffer.cc
     ${SRC_TEST}/test_syslog_tsdb_metric_formatter.cc
+    ${SRC_TEST}/test_unique_readsafe_ptr.cc
     ${SRC_TEST}/test.cc)
 
 set(TEST_UTIL_FILES

--- a/recorder/src/main/cpp/controller.cc
+++ b/recorder/src/main/cpp/controller.cc
@@ -624,10 +624,7 @@ void Controller::issue(const recording::CpuSampleWork& csw, Processes& processes
 }
 
 void Controller::retire(const recording::CpuSampleWork& csw) {
-    auto freq = csw.frequency();
-    auto max_stack_depth = csw.max_frames();
-    logger->info("Stopping cpu-sampling", freq, max_stack_depth);
-
+    logger->info("Stopping cpu-sampling");
     GlobalCtx::recording.cpu_profiler->stop();
     GlobalCtx::recording.cpu_profiler.reset();
 }

--- a/recorder/src/main/cpp/globals.hh
+++ b/recorder/src/main/cpp/globals.hh
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <chrono>
 #include "metrics.hh"
+#include "unique_readsafe_ptr.hh"
 
 #define SPDLOG_ENABLE_SYSLOG
 #include <spdlog/spdlog.h>
@@ -44,7 +45,7 @@ class Profiler;
 
 namespace GlobalCtx {
     typedef struct {
-        std::shared_ptr<Profiler> cpu_profiler;
+        UniqueReadsafePtr<Profiler> cpu_profiler;
     } Rec;
 
     extern GlobalCtx::Rec recording;

--- a/recorder/src/main/cpp/processor.cc
+++ b/recorder/src/main/cpp/processor.cc
@@ -25,6 +25,11 @@ Processor::Processor(jvmtiEnv* _jvmti, Processes&& _processes)
 
       s_t_yield_tm(GlobalCtx::metrics_registry->new_timer({METRICS_DOMAIN, "processor", "sched_yield", "time"})) {}
 
+Processor::~Processor() {
+    for (auto& p : processes) {
+        delete p;
+    }
+}
 
 void Processor::run() {
     while (true) {

--- a/recorder/src/main/cpp/processor.hh
+++ b/recorder/src/main/cpp/processor.hh
@@ -22,6 +22,8 @@ class Processor {
 public:
     explicit Processor(jvmtiEnv* _jvmti, Processes&& _tasks);
 
+    ~Processor();
+
     void start(JNIEnv *jniEnv);
 
     void run();

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -3,11 +3,18 @@
 ASGCTType Asgct::asgct_;
 IsGCActiveType Asgct::is_gc_active_;
 
+static thread_local std::atomic<bool> in_handler{false};
+
 static void handle_profiling_signal(int signum, siginfo_t *info, void *context) {
-    ReadsafePtr<Profiler> p(GlobalCtx::recording.cpu_profiler);
-    if (p.available()) {
-        p->handle(signum, info, context);
+    if (in_handler.load(std::memory_order_seq_cst)) return;
+    in_handler.store(true, std::memory_order_seq_cst);
+    {
+        ReadsafePtr<Profiler> p(GlobalCtx::recording.cpu_profiler);
+        if (p.available()) {
+            p->handle(signum, info, context);
+        }
     }
+    in_handler.store(false, std::memory_order_seq_cst);
 }
 
 void Profiler::handle(int signum, siginfo_t *info, void *context) {
@@ -26,13 +33,10 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
             do_record = ctx_tracker->in_ctx() ? ctx_tracker->should_record() : prob_pct.on(current_sampling_attempt, noctx_cov_pct);
         }
         if (! do_record) {
-            SPDLOG_DEBUG(logger, "Ignoring the sampling opportunity");
             return;
         }
     }
-    SimpleSpinLockGuard<false> guard(ongoing_conf); // sync buffer
 
-    // sample data structure
     STATIC_ARRAY(frames, JVMPI_CallFrame, capture_stack_depth(), MAX_FRAMES_TO_CAPTURE);
 
     JVMPI_CallTrace trace;
@@ -60,9 +64,6 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
 }
 
 bool Profiler::start(JNIEnv *jniEnv) {
-    SimpleSpinLockGuard<true> guard(ongoing_conf);
-    /* within critical section */
-
     if (running) {
         logger->warn("Start called but sampling is already running");
         return true;
@@ -77,9 +78,6 @@ bool Profiler::start(JNIEnv *jniEnv) {
 }
 
 void Profiler::stop() {
-    /* Make sure it doesn't overlap with configure */
-    SimpleSpinLockGuard<true> guard(ongoing_conf);
-
     if (!running) {
         return;
     }
@@ -113,7 +111,7 @@ void Profiler::configure() {
 
 Profiler::Profiler(JavaVM *_jvm, jvmtiEnv *_jvmti, ThreadMap &_thread_map, ProfileSerializingWriter& _serializer, std::uint32_t _max_stack_depth, std::uint32_t _sampling_freq, ProbPct& _prob_pct, std::uint8_t _noctx_cov_pct)
     : jvm(_jvm), jvmti(_jvmti), thread_map(_thread_map), max_stack_depth(_max_stack_depth), serializer(_serializer),
-      ongoing_conf(false), prob_pct(_prob_pct), sampling_attempts(0), noctx_cov_pct(_noctx_cov_pct), running(false), samples_handled(0),
+      prob_pct(_prob_pct), sampling_attempts(0), noctx_cov_pct(_noctx_cov_pct), running(false), samples_handled(0),
 
       s_c_cpu_samp_total(GlobalCtx::metrics_registry->new_counter({METRICS_DOMAIN, METRIC_TYPE, "opportunities"})),
 
@@ -129,7 +127,6 @@ Profiler::Profiler(JavaVM *_jvm, jvmtiEnv *_jvmti, ThreadMap &_thread_map, Profi
 }
 
 Profiler::~Profiler() {
-    SimpleSpinLockGuard<false> guard(ongoing_conf); // nonblocking
     if (running) stop();
     delete handler;
     delete buffer;

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -4,11 +4,9 @@ ASGCTType Asgct::asgct_;
 IsGCActiveType Asgct::is_gc_active_;
 
 static void handle_profiling_signal(int signum, siginfo_t *info, void *context) {
-    std::shared_ptr<Profiler> cpu_profiler = GlobalCtx::recording.cpu_profiler;
-    if (cpu_profiler.get() == nullptr) {
-        //ignore, can't log, because of re-entrance issues
-    } else {
-        cpu_profiler->handle(signum, info, context);
+    ReadsafePtr<Profiler> p(GlobalCtx::recording.cpu_profiler);
+    if (p.available()) {
+        p->handle(signum, info, context);
     }
 }
 

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -6,7 +6,7 @@ IsGCActiveType Asgct::is_gc_active_;
 static void handle_profiling_signal(int signum, siginfo_t *info, void *context) {
     std::shared_ptr<Profiler> cpu_profiler = GlobalCtx::recording.cpu_profiler;
     if (cpu_profiler.get() == nullptr) {
-        logger->warn("Received profiling signal while recording is off! Something wrong?");
+        //ignore, can't log, because of re-entrance issues
     } else {
         cpu_profiler->handle(signum, info, context);
     }

--- a/recorder/src/main/cpp/profiler.hh
+++ b/recorder/src/main/cpp/profiler.hh
@@ -86,9 +86,6 @@ private:
 
     ProfileSerializingWriter& serializer;
 
-    // indicates change of internal state
-    std::atomic<bool> ongoing_conf;
-
     ProbPct& prob_pct;
     std::atomic<std::uint32_t> sampling_attempts;
     const std::uint8_t noctx_cov_pct;

--- a/recorder/src/main/cpp/unique_readsafe_ptr.hh
+++ b/recorder/src/main/cpp/unique_readsafe_ptr.hh
@@ -1,0 +1,70 @@
+#ifndef UNIQUE_READSAFE_PTR_H
+#define UNIQUE_READSAFE_PTR_H
+
+#include <memory>
+#include <cstdint>
+
+template <typename T> class UniqueReadsafePtr;
+
+template <typename T> class ReadsafePtr {
+private:
+    UniqueReadsafePtr<T>& ptr;
+    bool ref_count_incremented;
+    bool _available;
+
+public:
+    ReadsafePtr(UniqueReadsafePtr<T>& _ptr) : ptr(_ptr), ref_count_incremented(false) {
+        if (ptr.available.load(std::memory_order_seq_cst)) {
+            ptr.reader_count.fetch_add(1, std::memory_order_seq_cst);
+            ref_count_incremented = true;
+            _available = ptr.available.load(std::memory_order_seq_cst);
+        }
+    }
+
+    ~ReadsafePtr() {
+        if (ref_count_incremented) {
+            ptr.reader_count.fetch_sub(1, std::memory_order_seq_cst);
+        }
+    }
+
+    bool available() { return _available; }
+
+    T* operator->() {
+        return _available ? ptr.ptr.get() : nullptr;
+    }
+
+private:
+    ReadsafePtr(const ReadsafePtr&);
+    void operator=(const ReadsafePtr&);
+};
+
+template <typename T> class UniqueReadsafePtr {
+private:
+    std::unique_ptr<T> ptr;
+    std::atomic<bool> available;
+    std::atomic<std::uint32_t> reader_count;
+
+    friend class ReadsafePtr<T>;
+
+public:
+    UniqueReadsafePtr() : available(false), reader_count(0) {}
+
+    ~UniqueReadsafePtr() {
+        SPDLOG_TRACE(logger, "Destructor called");
+        reset();
+        SPDLOG_TRACE(logger, "Destructor COMPLETE");
+    }
+
+    void reset(T* t = nullptr) {
+        available.store(false, std::memory_order_seq_cst);
+        while (reader_count.load(std::memory_order_seq_cst) > 0);
+        ptr.reset(t);
+        if (t != nullptr) available.store(true, std::memory_order_seq_cst);
+    }
+
+private:
+    UniqueReadsafePtr(const UniqueReadsafePtr&);
+    void operator=(const UniqueReadsafePtr&);
+};
+
+#endif

--- a/recorder/src/main/cpp/unique_readsafe_ptr.hh
+++ b/recorder/src/main/cpp/unique_readsafe_ptr.hh
@@ -14,7 +14,7 @@ private:
 
 public:
     ReadsafePtr(UniqueReadsafePtr<T>& _ptr) : ptr(_ptr), ref_count_incremented(false) {
-        if (ptr.available.load(std::memory_order_seq_cst)) {
+        if ((_available = ptr.available.load(std::memory_order_seq_cst))) {
             ptr.reader_count.fetch_add(1, std::memory_order_seq_cst);
             ref_count_incremented = true;
             _available = ptr.available.load(std::memory_order_seq_cst);
@@ -50,9 +50,7 @@ public:
     UniqueReadsafePtr() : available(false), reader_count(0) {}
 
     ~UniqueReadsafePtr() {
-        SPDLOG_TRACE(logger, "Destructor called");
         reset();
-        SPDLOG_TRACE(logger, "Destructor COMPLETE");
     }
 
     void reset(T* t = nullptr) {

--- a/recorder/src/test/cpp/main.cc
+++ b/recorder/src/test/cpp/main.cc
@@ -1,7 +1,16 @@
 #include "test.hh"
+#include <cstring>
+#include "TestReporterStdout.h"
 
-int main() {
-    auto ret = UnitTest::RunAllTests();
+using namespace UnitTest;
+
+int main(int argc, char** argv ) {
+    TestReporterStdout reporter;
+    TestRunner runner(reporter);
+    auto ret = runner.RunTestsIf(Test::GetTestList(), NULL, [argc, argv](Test* t) {
+            if (argc == 1) return true;
+            return strstr(t->m_details.testName, argv[1]) != nullptr;
+        }, 0);
     logger.reset();
     return ret;
 }

--- a/recorder/src/test/cpp/test_unique_readsafe_ptr.cc
+++ b/recorder/src/test/cpp/test_unique_readsafe_ptr.cc
@@ -1,0 +1,74 @@
+#include <thread>
+#include <vector>
+#include <iostream>
+#include <cstdint>
+#include <chrono>
+#include "fixtures.hh"
+#include "test.hh"
+#include "../../main/cpp/unique_readsafe_ptr.hh"
+
+struct DestructorTracker {
+    std::atomic<bool>& destroyed;
+    std::atomic<std::uint64_t>& destroyed_at_usec;
+    std::atomic<std::uint64_t>& last_read_at_usec;
+    std::chrono::time_point<std::chrono::system_clock> created_at;
+    std::atomic<std::uint32_t>& destroyed_before_read;
+
+    DestructorTracker(std::atomic<bool>& _destroyed, std::atomic<std::uint64_t>& _destroyed_at_usec, std::atomic<std::uint64_t>& _last_read_at_usec, std::chrono::time_point<std::chrono::system_clock> _created_at, std::atomic<std::uint32_t>& _destroyed_before_read) :
+        destroyed(_destroyed), destroyed_at_usec(_destroyed_at_usec), last_read_at_usec(_last_read_at_usec), created_at(_created_at), destroyed_before_read(_destroyed_before_read) {
+        last_read_at_usec.store(0, std::memory_order_seq_cst);
+        destroyed.store(false, std::memory_order_seq_cst);
+    }
+    ~DestructorTracker() {
+        destroyed.store(true, std::memory_order_seq_cst);
+        destroyed_at_usec.store(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - created_at).count());
+    }
+    void read() {
+        last_read_at_usec.store(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - created_at).count());
+        if (destroyed.load(std::memory_order_seq_cst)) {
+            destroyed_before_read.fetch_add(1, std::memory_order_seq_cst);
+        }
+    }
+};
+
+void readref_and_sleep_for(std::uint32_t ms, UniqueReadsafePtr<DestructorTracker>& urp, std::atomic<std::uint32_t>& started) {
+    ReadsafePtr<DestructorTracker> rp(urp);
+    logger->info("Flipped...");
+    started.fetch_add(1, std::memory_order_seq_cst);
+    logger->info("Started...");
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    rp->read();
+    logger->info("Read done...");
+}
+
+TEST(ReadsafePtr___should_not_destruct___until_all_readers_are_done) {
+    TestEnv _;
+
+    std::atomic<bool> destroyed;
+    std::atomic<std::uint64_t> destroyed_at_usec;
+    std::atomic<std::uint64_t> last_read_at_usec;
+    std::atomic<std::uint32_t> destroyed_before_read {0};
+    std::thread* t1;
+    std::thread* t2;
+    std::atomic<std::uint32_t> started {0};
+    std::chrono::time_point<std::chrono::system_clock> scope_ended_at;
+    std::chrono::time_point<std::chrono::system_clock> object_created_at;
+    {
+        UniqueReadsafePtr<DestructorTracker> p;
+        object_created_at = std::chrono::system_clock::now();
+        p.reset(new DestructorTracker(destroyed, destroyed_at_usec, last_read_at_usec, object_created_at, destroyed_before_read));
+        t1 = new std::thread { readref_and_sleep_for, 10, std::ref(p), std::ref(started) };
+        t2 = new std::thread { readref_and_sleep_for, 20, std::ref(p), std::ref(started) };
+        while (started.load(std::memory_order_seq_cst) < 2);
+        scope_ended_at = std::chrono::system_clock::now();
+        logger->info("End of scope reached...");
+    }
+    logger->info("Came out of scope...");
+    std::uint32_t destruct_time_lag = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - scope_ended_at).count();
+    t1->join();
+    t2->join();
+
+    CHECK(destruct_time_lag >= (20 * 1000));//atleast 20 ms
+    CHECK(last_read_at_usec.load() <= destroyed_at_usec.load());
+    CHECK_EQUAL(0, destroyed_before_read.load(std::memory_order_seq_cst));
+}


### PR DESCRIPTION
Fixes: https://github.com/Flipkart/fk-prof/issues/68

Basically Profile::handle wasn't signal-handling capable. This prevents re-entrance and ensures no alloc/free happens in sig-hdlr.