### PR TITLE
Fixed perfctx bad-pairing detection and reporting

### DIFF
--- a/perfctx/src/main/java/fk/prof/IncorrectContextException.java
+++ b/perfctx/src/main/java/fk/prof/IncorrectContextException.java
@@ -1,4 +1,7 @@
 package fk.prof;
 
 public class IncorrectContextException extends RuntimeException {
+    public IncorrectContextException(String message) {
+        super(message);
+    }
 }

--- a/recorder/src/main/cpp/perf_ctx.hh
+++ b/recorder/src/main/cpp/perf_ctx.hh
@@ -109,7 +109,6 @@ namespace PerfCtx {
         metrics::Ctr& s_c_merge_new;
 
         void load_unused_primes(std::uint32_t count);
-        void name_for(TracePt pt, std::string& name) throw (UnknownCtx);
 
     public:
         Registry();
@@ -117,13 +116,21 @@ namespace PerfCtx {
         
         TracePt find_or_bind(const char* name, std::uint8_t coverage_pct, std::uint8_t merge_type) throw (CtxCreationFailure);
         TracePt merge_bind(const std::vector<ThreadCtx>& parent, bool strict = false);
+        void name_for(TracePt pt, std::string& name) throw (UnknownCtx);
         void resolve(TracePt pt, std::string& name, bool& is_generated, std::uint8_t& coverage_pct, MergeSemantic& m_sem) throw (UnknownCtx);
     };
 
-    class IncorrectEnterExitPairing : public std::runtime_error {
+    class IncorrectEnterExitPairing {
+        std::string msg;
+
     public:
-        IncorrectEnterExitPairing(const TracePt expected, const TracePt got) : runtime_error(Util::to_s("Expected ", expected, " got ", got)) {};
-        virtual ~IncorrectEnterExitPairing() {}
+        IncorrectEnterExitPairing(Registry& reg, const TracePt expected, const TracePt got);
+
+        IncorrectEnterExitPairing(Registry& reg, const TracePt got);
+
+        ~IncorrectEnterExitPairing() {}
+
+        const char* what() const;
     };
 
     MergeSemantic merge_semantic(TracePt pt);

--- a/recorder/src/test/cpp/test_jni.cc
+++ b/recorder/src/test/cpp/test_jni.cc
@@ -69,7 +69,7 @@ JNIEXPORT jint JNICALL Java_fk_prof_TestJni_getCurrentCtx(JNIEnv* jni, jobject s
     }
 
     if (jni->GetArrayLength(arr) < PerfCtx::MAX_NESTING) {
-        jni->ThrowNew(jni->FindClass("java/lang/IllegalArgumentException"), Util::to_s("Got a very small array, need array with length > ", PerfCtx::MAX_NESTING).c_str());
+        jni->ThrowNew(jni->FindClass("java/lang/IllegalArgumentException"), Util::to_s("Got a very small array, need array with length > ", static_cast<std::int32_t>(PerfCtx::MAX_NESTING)).c_str());
         return -1;
     }
 

--- a/recorder/src/test/java/fk/prof/PerfCtxUnitTest.java
+++ b/recorder/src/test/java/fk/prof/PerfCtxUnitTest.java
@@ -398,7 +398,7 @@ public class PerfCtxUnitTest {
         List<PerfCtx> defs = new ArrayList<>();
         int i;
         int limit = 224;
-        for (i = 0; i < limit/5; i++) {
+        for (i = 0; i < limit / 5; i++) {
             for (MergeSemantics mSem : MergeSemantics.values()) {
                 defs.add(new PerfCtx(String.format("%s - %s", mSem, i), i, mSem));
             }
@@ -407,7 +407,7 @@ public class PerfCtxUnitTest {
             MergeSemantics mSem = MergeSemantics.DUPLICATE;
             defs.add(new PerfCtx(String.format("%s - %s", mSem, i + j), i + j, mSem));
         }
-        
+
         assertThat(defs.size(), is(224));
 
         try {
@@ -416,5 +416,60 @@ public class PerfCtxUnitTest {
         } catch (PerfCtxInitException e) {
             assertThat(e.getMessage(), is("PerfCtx creation failed: Too many (~ 224) ctxs have been created."));
         }
+    }
+
+    @Test
+    public void shouldFail_IncorrectPairingOf_ContextEnterExitCalls() {
+        PerfCtx foo = new PerfCtx("foo");
+        PerfCtx bar = new PerfCtx("bar", 10, MergeSemantics.STACK_UP);
+        long[] ctxIds = new long[5];
+
+        assertThat(testJni.getCurrentCtx(ctxIds), is(0));
+        try {
+            bar.end();
+        } catch (IncorrectContextException e) {
+            assertThat(e.getMessage(), is("Unexpected exit for 'bar'(747597538143502339)"));
+        }
+        assertThat(testJni.getCurrentCtx(ctxIds), is(0));
+
+        foo.begin();
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("foo"));
+        try {
+            bar.end();
+        } catch (IncorrectContextException e) {
+            assertThat(e.getMessage(), is("Expected exit for 'foo'(720575940379279362) got 'bar'(747597538143502339)"));
+        }
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("foo"));
+
+        bar.begin();
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("bar"));
+        try {
+            foo.end();
+        } catch (IncorrectContextException e) {
+            assertThat(e.getMessage(), is("Expected exit for 'bar'(747597538143502339) got 'foo'(720575940379279362)"));
+        }
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("bar"));
+        bar.end();
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("foo"));
+        try {
+            bar.end();
+        } catch (IncorrectContextException e) {
+            assertThat(e.getMessage(), is("Expected exit for 'foo'(720575940379279362) got 'bar'(747597538143502339)"));
+        }
+        assertThat(testJni.getCurrentCtx(ctxIds), is(1));
+        assertThat(testJni.getCtxName(ctxIds[0]), is("foo"));
+        foo.end();
+        assertThat(testJni.getCurrentCtx(ctxIds), is(0));
+        try {
+            foo.end();
+        } catch (IncorrectContextException e) {
+            assertThat(e.getMessage(), is("Unexpected exit for 'foo'(720575940379279362)"));
+        }
+        assertThat(testJni.getCurrentCtx(ctxIds), is(0));
     }
 }


### PR DESCRIPTION
There were 2 problems, "reporting thru jni wrapper was broken" and "detection of the case when user calls end before begin was overlooked". This fixed both + enhances reporting to include ctx name in exception message. A test now excercises this flow from java.