### PR TITLE
Do not log curl reponses to stdout, give them to logger

### DIFF
--- a/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/CpuSamplingTest.java
@@ -21,6 +21,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import recording.Recorder;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -519,7 +520,7 @@ public class CpuSamplingTest {
 
         profile[0] = (req) -> {
             recordProfile(req, hdr, profileEntries);
-            return new byte[0];
+            return "Processed profile successfully!".getBytes(Charset.forName("UTF-8"));
         };
         profile[1] = (req) -> {
             profileCalledSecondTime.setTrue();


### PR DESCRIPTION
It was polluting target-process' stdout. This folds it into our log-dest.