### PR TITLE
UI: Rewrite of rendering of stack traces (trees) and associated bugfixes

### DIFF
--- a/ui/app/components/AppComponent/AppComponent.js
+++ b/ui/app/components/AppComponent/AppComponent.js
@@ -83,7 +83,7 @@ const AppComponent = (props) => {
       {
         selectedProc && start && end && (
           <div className="mdl-grid">
-            <div className="mdl-cell mdl-cell--4-col">
+            <div className="mdl-cell mdl-cell--3-col">
               <ProfileList
                 app={selectedApp}
                 cluster={selectedCluster}
@@ -92,7 +92,7 @@ const AppComponent = (props) => {
                 end={end}
               />
             </div>
-            <div className="mdl-cell mdl-cell--8-col">
+            <div className="mdl-cell mdl-cell--9-col">
               {props.children || <h2 className={styles.ingrained}>Select a Trace</h2>}
             </div>
           </div>

--- a/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
+++ b/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
@@ -113,6 +113,7 @@ export class CPUSamplingComponent extends Component {
                 nodes={safeTraverse(this.props, ['tree', 'data', 'terminalNodes'])}
                 nextNodesAccessorField="parent"
                 methodLookup={safeTraverse(this.props, ['tree', 'data', 'methodLookup'])}
+                filterKey="cs_hm_filter"
               />
             </div>
           </div>
@@ -127,6 +128,7 @@ export class CPUSamplingComponent extends Component {
                 nextNodesAccessorField="children"
                 methodLookup={safeTraverse(this.props, ['tree', 'data', 'methodLookup'])}
                 percentageDenominator={safeTraverse(this.props, ['tree', 'data', 'treeRoot', 'onStack'])}
+                filterKey="cs_ct_filter"
               />
             </div>
           </div>

--- a/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
+++ b/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
@@ -127,7 +127,6 @@ export class CPUSamplingComponent extends Component {
                 nodeIndexes={safeTraverse(this.props, ['tree', 'data', 'treeRoot', 'children'])}
                 nextNodesAccessorField="children"
                 methodLookup={safeTraverse(this.props, ['tree', 'data', 'methodLookup'])}
-                percentageDenominator={safeTraverse(this.props, ['tree', 'data', 'treeRoot', 'onStack'])}
                 filterKey="cs_ct_filter"
               />
             </div>

--- a/ui/app/components/MethodTreeComponent/MethodTreeComponent.css
+++ b/ui/app/components/MethodTreeComponent/MethodTreeComponent.css
@@ -1,16 +1,6 @@
-.label {
-  color: #666;
-}
-
-.bold {
-  font-weight: bold;
-}
-
-.filter {
-  padding: 6px;
-  border: 1px solid #eee;
-  margin-left: 20px;
-  font-size: 0.7em;
+.filterBox {
+  font-size: 14px;
+  width: 200px;
 }
 
 .alert {
@@ -21,84 +11,8 @@
   font-size: 16px;
 }
 
-.card {
-  padding: 4px;
-  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
-  border-radius: 2px;
-}
-
-.listItem {
-  display: inline-block;
-  height: 14px;
-}
-
-.hover {
-  padding: 1px;
-  border-bottom: 1px solid rgba(158, 158, 158, 0.28);
-  &:HOVER {
-    background: #eee;
-  }
-}
-
-.pill {
-  display: inline-block;
-  width: 90px;
-  font-weight: bold;
-  color: #ff4081;
-}
-
-.onCPU {
-  position: absolute;
-  right: 110px;
-  width: 100px;
-}
-
-.onStack {
-  position: absolute;
-  right: 0px;
-  width: 100px;
-}
-
-.relative {
-  position: relative;
-}
-
-.code {
-  position: absolute;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  left: 14px;
-  white-space: nowrap;
-  right: 220px;
-}
-
-.heading {
-  font-weight: bold;
-  text-align: center;
-}
-
-.number {
-  text-align: left;
-  display: inline-block;
-  width: 30%;
-}
-
-.percentage {
-  text-align: center;
-  display: inline-block;
-  position: relative;
-  width: 70%;
-  .shade {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    background: #ff4081;
-    opacity: 0.2;
-    height: inherit;
-  }
-}
-
-.yellow {
-  background: #9DFF0A;
+input:focus {
+  border-radius: 0px;
+  outline-width: 1px;
+  outline-color: rgb(63,81,181);
 }

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
@@ -98,3 +98,7 @@ th.fixedRightCol1 {
 .highlight {
   filter: saturate(8);
 }
+
+.subdued {
+  color: rgba(0,0,0,0.6);
+}

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
@@ -1,0 +1,107 @@
+.container { 
+  width: auto; 
+  overflow-x: scroll;  
+  margin-right: 220px;
+  overflow-y: visible;
+  margin-left: 10px;
+}
+
+.container table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin-bottom: 0;
+  width: 100%;
+  max-width: 100%;  
+}
+
+.container tbody>tr:hover .fixedRightCol1, .container tbody>tr:hover .fixedRightCol2, .container tbody>tr:hover .stackline {
+    background-color: #f0f0f0;  
+}
+
+.container tr {
+  background: white;
+}
+
+.container th {
+  padding: 5px;
+  vertical-align: top;
+  text-align: left;
+  color: rgb(255,64,129);
+}
+
+.container td {
+  margin: 0;
+  white-space: nowrap;
+  padding: 2px;
+  vertical-align: top;
+}
+
+.nodeIcon {
+  font-size: 14px;
+  vertical-align: text-top;
+  cursor: pointer;
+  cursor: hand;
+}
+
+.stackline {
+  border-bottom: 1px solid rgba(158, 158, 158, 0.28);  
+}
+
+.stacklineText {
+  cursor: pointer;
+  cursor: hand;
+  &:HOVER {
+    color: rgb(255,64,129);
+  }
+}
+
+.fixedRightCol1 {
+  position: absolute; 
+  width: 100px; 
+  right: 16px;
+  top: auto;
+}
+
+.fixedRightCol2 {
+  position: absolute; 
+  width: 100px; 
+  right: 120px;
+  top: auto;
+}
+
+td.fixedRightCol1>div, td.fixedRightCol2>div  {
+  border-bottom: 1px solid rgba(158, 158, 158, 0.28);
+}
+
+.pill {
+  background: white;
+  display: inline-block;
+  width: 100px;
+  font-weight: bold;
+}
+
+.percentage {
+  text-align: center;
+  display: inline-block;
+  position: relative;
+  width: 70%;
+  .shade {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    background-color: rgb(255,64,129);
+    opacity: 0.2;
+    height: inherit;
+  }
+}
+
+.number {
+  text-align: left;
+  display: inline-block;
+  width: 30%;
+}
+
+.inverted {
+  filter: saturate(8);
+}

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.css
@@ -39,6 +39,12 @@
   cursor: hand;
 }
 
+.collapsedIcon {
+  -ms-transform: rotate(90deg); /* IE 9 */
+  -webkit-transform: rotate(90deg); /* Chrome, Safari, Opera */
+  transform: rotate(90deg);
+}
+
 .stackline {
   border-bottom: 1px solid rgba(158, 158, 158, 0.28);  
 }

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import styles from './StackTreeElementComponent.css';
+
+class StackTreeElementComponent extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  getIconForNode() {
+    switch(this.props.nodestate) {
+      case true:
+        return "expand_less";
+      case false:
+      default:
+        return "expand_more";
+    }
+  }
+
+  getIconForHighlight() {
+    return this.props.highlight ? "highlight" : "lightbulb_outline";
+  }
+
+  render () {
+    let leftPadding = ((this.props.indent || 0) * 7) + "px";
+    return (
+      <tr className={this.props.highlight && styles.inverted}>
+        <td className={styles.fixedRightCol1}>
+          {this.props.onstack ? (
+            <div className={`${styles.pill} mdl-color-text--primary`}>
+              <div className={styles.number}>{this.props.onstack}</div>
+              <div className={styles.percentage}>
+                <div className={styles.shade} style={{ width: `${this.props.onstackPct}%` }} />
+                {this.props.onstackPct}%
+              </div>
+            </div>
+          ) : <div>&nbsp;</div>}
+        </td>
+        <td className={styles.fixedRightCol2}>
+          {!!this.props.oncpu ? (
+            <div className={`${styles.pill} mdl-color-text--primary`}>
+              <div className={styles.number}>{this.props.oncpu}</div>
+              <div className={styles.percentage}>
+                <div className={styles.shade} style={{ width: `${this.props.oncpuPct}%` }} />
+                {this.props.oncpuPct}%
+              </div>
+            </div>
+          ) : <div>&nbsp;</div>}
+        </td>
+        <td>
+          <div className={styles.stackline} style={{marginLeft: leftPadding}} title={this.props.stackline}>
+            <span className={`material-icons mdl-color-text--primary-dark ${styles.nodeIcon}`} onClick={this.props.onHighlight}>
+              {this.getIconForHighlight()}
+            </span>
+            <span className={styles.stacklineText} onClick={this.props.onClick}>
+              <span className={`material-icons mdl-color-text--primary-dark ${styles.nodeIcon}`}>
+                {this.getIconForNode()}
+              </span>
+              <span className={`${this.props.highlight && 'mdl-color-text--primary'}`}>{this.props.stackline}</span>
+            </span>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+}
+
+export default StackTreeElementComponent;

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
@@ -10,9 +10,9 @@ class StackTreeElementComponent extends Component {
 
   getStyleAndIconForNode() {
     if (this.props.nodestate) {
-      return [0, "remove"];
+      return [styles.collapsedIcon, "play_arrow"];
     } else {
-      return ["mdl-color-text--accent", "add"];
+      return ["mdl-color-text--accent", "play_arrow"];
     }
   }
 

--- a/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
+++ b/ui/app/components/StackTreeElementComponent/StackTreeElementComponent.js
@@ -8,13 +8,11 @@ class StackTreeElementComponent extends Component {
     };
   }
 
-  getIconForNode() {
-    switch(this.props.nodestate) {
-      case true:
-        return "expand_less";
-      case false:
-      default:
-        return "expand_more";
+  getStyleAndIconForNode() {
+    if (this.props.nodestate) {
+      return [0, "remove"];
+    } else {
+      return ["mdl-color-text--accent", "add"];
     }
   }
 
@@ -23,9 +21,9 @@ class StackTreeElementComponent extends Component {
   }
 
   render () {
-    let leftPadding = ((this.props.indent || 0) * 7) + "px";
+    let leftPadding = (this.props.indent || 0) + "px";
     return (
-      <tr className={this.props.highlight && styles.highlight}>
+      <tr className={this.props.highlight ? styles.highlight : this.props.subdued && styles.subdued}>
         <td className={styles.fixedRightCol1}>
           {this.props.samples ? (
             <div className={`${styles.pill} mdl-color-text--primary`}>
@@ -43,8 +41,8 @@ class StackTreeElementComponent extends Component {
               {this.getIconForHighlight()}
             </span>
             <span className={styles.stacklineText} onClick={this.props.onClick}>
-              <span className={`material-icons mdl-color-text--primary ${styles.nodeIcon}`}>
-                {this.getIconForNode()}
+              <span className={`material-icons ${this.getStyleAndIconForNode()[0]} ${styles.nodeIcon}`}>
+                {this.getStyleAndIconForNode()[1]}
               </span>
               <span className={`${this.props.highlight && 'mdl-color-text--primary'}`}>{this.props.stackline}</span>
             </span>

--- a/ui/app/components/StackTreeElementComponent/index.js
+++ b/ui/app/components/StackTreeElementComponent/index.js
@@ -1,0 +1,3 @@
+import StackTreeElementComponent from './StackTreeElementComponent';
+
+export default StackTreeElementComponent;

--- a/userapi/src/main/resources/log4j2.xml
+++ b/userapi/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5p} [%t] %blue{%c{4}} - %m%n"/>
+    </Console>
+    <Console name="request" target="SYSTEM_OUT">
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <AsyncLogger name="fk" level="debug" />
+    <AsyncLogger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="info" additivity="false">
+      <AppenderRef ref="request"/>
+    </AsyncLogger>
+    <AsyncRoot level="info">
+      <AppenderRef ref="console"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
- Removed react tree view dependency, added custom rendering of tree
using tables. Rewrite essential to support horizontal scrolling of
method names reported in issue #88
- Supports horizontal scrolling of trace lines, while keeping right
columns fixed
- Auto expand functionality added for nodes in tree with single child
- Click on method(tree element) expands/collapses rather than
highlighting. Reported in #88
- Separate button per row to highlight. Changed css styling of
highlight functionality
- Overall cleanup of css styling in tree. Hover on node highlights
text, changed icons of expand collapse, feature parity with old tree
view rendering in other places
- Material design friendly filter box for traces
- Bugfix: #113 Independent filters for hot methods and call tree for
cpu sampling