### PR TITLE
Fix thread info jvmpi error invariant

### DIFF
--- a/recorder/src/main/cpp/profile_writer.cc
+++ b/recorder/src/main/cpp/profile_writer.cc
@@ -123,7 +123,8 @@ void ProfileSerializingWriter::record(const JVMPI_CallTrace &trace, ThreadBucket
             ss->set_thread_id(known_thd->second);
         }
         info->release();
-    } else {
+    }
+    if (trace.num_frames <= 0) {
         ss->set_error(translate_forte_error(trace.num_frames));
     }
 


### PR DESCRIPTION
Removes the assumption that thread_info == nullptr implies jvmpi-error in AGCT.

Also, fixed the circular-queue to not re-order input-output pointer load/store.