### PR TITLE
Changes in userapi to improve loading of profiles.

### DIFF
--- a/backend/src/test/resources/config.json
+++ b/backend/src/test/resources/config.json
@@ -79,12 +79,12 @@
       "maxsize": 5,
       "idletime.secs": 60,
       "queue.maxsize": 50
-    },
-    "aggregatedProfiles.baseDir": "profiles"
+    }
   },
   "bufferPoolOptions" : {
     "max.total": 20,
     "max.idle": 20,
     "buffer.size": 10000000
-  }
+  },
+  "aggregatedProfiles.baseDir": "profiles"
 }

--- a/ui/app/components/AppComponent/AppComponent.js
+++ b/ui/app/components/AppComponent/AppComponent.js
@@ -14,7 +14,7 @@ const AppComponent = (props) => {
   const selectedCluster = props.location.query.cluster;
   const selectedProc = props.location.query.proc;
   const start = props.location.query.start;
-  const end = start ? (new Date(start).getTime() + ((24 * 3600 * 1000) - 1)) : '';
+  const end = start ? (new Date(start).getTime() + (24 * 3600 * 1000)) : '';
 
   const updateQueryParams = ({ pathname = '/', query }) => props.router.push({ pathname, query });
   const updateAppQueryParam = o => updateQueryParams({ query: { app: o.name } });

--- a/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
+++ b/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
@@ -11,7 +11,7 @@ import styles from './CPUSamplingComponent.css';
 
 export class CPUSamplingComponent extends Component {
   componentDidMount () {
-    const { app, cluster, proc, workType, profileStart, selectedWorkType } = this.props.location.query;
+    const {app, cluster, proc, workType, profileStart, selectedWorkType, profileDuration} = this.props.location.query;
     const { traceName } = this.props.params;
     this.props.fetchCPUSampling({
       app,
@@ -20,12 +20,15 @@ export class CPUSamplingComponent extends Component {
       workType,
       selectedWorkType,
       traceName,
-      query: { start: profileStart },
+      query: {
+        start: profileStart,
+        duration: profileDuration
+      },
     });
   }
 
   componentWillReceiveProps (nextProps) {
-    const { app, cluster, proc, workType, profileStart, selectedWorkType } = nextProps.location.query;
+    const {app, cluster, proc, workType, profileStart, selectedWorkType, profileDuration} = nextProps.location.query;
     const didTraceNameChange = this.props.params.traceName !== nextProps.params.traceName;
     const didProfileChange = profileStart !== this.props.location.query.profileStart;
     if (didTraceNameChange || didProfileChange) {
@@ -37,7 +40,10 @@ export class CPUSamplingComponent extends Component {
         workType,
         selectedWorkType,
         traceName,
-        query: { start: profileStart },
+        query: {
+          start: profileStart,
+          duration: profileDuration
+        },
       });
     }
   }
@@ -158,6 +164,7 @@ CPUSamplingComponent.propTypes = {
       workType: PropTypes.string,
       profileStart: PropTypes.string,
       selectedWorkType: PropTypes.string,
+      profileDuration: PropTypes.string
     }),
   }),
 };

--- a/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
+++ b/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
@@ -1,12 +1,12 @@
-import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
+import React, {Component, PropTypes} from "react";
+import {connect} from "react-redux";
 
-import fetchCPUSamplingAction from 'actions/AggregatedProfileDataActions';
-import safeTraverse from 'utils/safeTraverse';
-import Loader from 'components/LoaderComponent';
-import MethodTree from 'components/MethodTreeComponent';
-import Tabs from 'components/Tabs';
-import styles from './CPUSamplingComponent.css';
+import fetchCPUSamplingAction from "actions/AggregatedProfileDataActions";
+import safeTraverse from "utils/safeTraverse";
+import Loader from "components/LoaderComponent";
+import MethodTree from "components/MethodTreeComponent";
+import Tabs from "components/Tabs";
+import styles from "./CPUSamplingComponent.css";
 
 
 export class CPUSamplingComponent extends Component {
@@ -164,7 +164,7 @@ CPUSamplingComponent.propTypes = {
       workType: PropTypes.string,
       profileStart: PropTypes.string,
       selectedWorkType: PropTypes.string,
-      profileDuration: PropTypes.string
+      profileDuration: PropTypes.number
     }),
   }),
 };

--- a/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
+++ b/ui/app/components/CPUSamplingComponent/CPUSamplingComponent.js
@@ -30,7 +30,7 @@ export class CPUSamplingComponent extends Component {
   componentWillReceiveProps (nextProps) {
     const {app, cluster, proc, workType, profileStart, selectedWorkType, profileDuration} = nextProps.location.query;
     const didTraceNameChange = this.props.params.traceName !== nextProps.params.traceName;
-    const didProfileChange = profileStart !== this.props.location.query.profileStart;
+    const didProfileChange = profileStart !== this.props.location.query.profileStart || profileDuration !== this.props.location.query.profileDuration;
     if (didTraceNameChange || didProfileChange) {
       const { traceName } = nextProps.params;
       this.props.fetchCPUSampling({

--- a/ui/app/components/ProfileComponent/ProfileComponent.js
+++ b/ui/app/components/ProfileComponent/ProfileComponent.js
@@ -99,7 +99,7 @@ class ProfileComponent extends React.Component {
   }
 
   render () {
-    const tracesScore = this.props.tracesScore ? this.props.tracesScore : [];    
+    const tracesScore = this.props.tracesScore ? this.props.tracesScore : [];
     const isCollapsable = tracesScore.length > this.state.collapseCount;
     const isCollapsed = (isCollapsable && this.state.collapse);
 
@@ -137,14 +137,14 @@ class ProfileComponent extends React.Component {
             />
           </div>
         )}
-        
+
         {list && list.length > 0 && (
           <div style={{padding: "4px 16px"}}>
             {list.map(l => (
               <div className={`${styles.itemContainer} ${(l.name === selectedTraceName && this.props.profile.start === selectedProfile) && styles.highlighted}`}
               key={l.name}>
                 <Link
-                  to={loc => ({ pathname: `/profiler/profile-data/${l.name}`, query: { ...loc.query, profileStart: this.props.profile.start }})}>
+                  to={loc => ({ pathname: `/profiler/profile-data/${l.name}`, query: { ...loc.query, profileStart: this.props.profile.start, profileDuration: this.props.profile.duration }})}>
                   <span>(</span><span className="mdl-color-text--primary">{l.score}</span><span>)</span>
                   <span>&nbsp;</span>
                   <span>{l.name}</span>
@@ -222,7 +222,7 @@ class ProfileComponent extends React.Component {
       const p_end = new Date(p_start.getTime() + (p.duration * 1000));
       const ip = p.recorder_info ? p.recorder_info.ip : "No available recorder";
       const vm = p.recorder_info ? p.recorder_info.vm_id : "";
-      const tooltip = '<div style="padding: 4px;"><div style="font-size: 14px;" class="mdl-color-text--primary">' + ip + '</div>' 
+      const tooltip = '<div style="padding: 4px;"><div style="font-size: 14px;" class="mdl-color-text--primary">' + ip + '</div>'
         + '<div style="font-size: 10px;">' + moment(p_start).format("HH:mm:ss") + ' - ' + moment(p_end).format("HH:mm:ss") + '</div></div>';
       stat.basic = [p.status, ip, tooltip, p_start, p_end];
       stat.tcov = p.trace_coverage_map;

--- a/userapi/src/main/conf/userapi-conf.json
+++ b/userapi/src/main/conf/userapi-conf.json
@@ -3,11 +3,11 @@
     "config": {
       "verticle.count": 1,
       "http.port": 8082,
-      "req.timeout": 2000
+      "req.timeout": 10000
     }
   },
   "profile.retention.duration.min": 30,
-  "aggregation_window.duration.secs": 1800,
+  "load.timeout": 10000,
   "storage": {
     "s3": {
       "endpoint": "http://127.0.0.1:13031",
@@ -22,5 +22,6 @@
       "queue.maxsize": 50
     }
   },
-  "aggregatedProfiles.baseDir": "profiles"
+  "aggregatedProfiles.baseDir": "profiles",
+  "vertx.worker.pool.size": 50
 }

--- a/userapi/src/main/conf/userapi-conf.json
+++ b/userapi/src/main/conf/userapi-conf.json
@@ -7,7 +7,7 @@
     }
   },
   "profile.retention.duration.min": 30,
-  "load.timeout": 10000,
+  "profile.load.timeout": 10000,
   "storage": {
     "s3": {
       "endpoint": "http://127.0.0.1:13031",

--- a/userapi/src/main/java/fk/prof/userapi/Configuration.java
+++ b/userapi/src/main/java/fk/prof/userapi/Configuration.java
@@ -22,8 +22,14 @@ public class Configuration {
     @JsonProperty("profile.retention.duration.min")
     private Integer profileRetentionDurationMin = 30;
 
-    @JsonProperty("aggregation_window.duration.secs")
-    private Integer aggregationWindowDurationSec = 1800;
+    @JsonProperty("max.aggregation_window.duration.days")
+    private Integer maxAggregationWindowDurationDays = 7;
+
+    @JsonProperty("load.timeout")
+    private Integer loadTimeout = 10000;
+
+    @JsonProperty("vertx.worker.pool.size")
+    private Integer vertxWorkerPoolSize;
 
     @NotNull
     @JsonProperty("userapiHttpOptions")
@@ -51,8 +57,16 @@ public class Configuration {
         return profileRetentionDurationMin;
     }
 
-    public Integer getAggregationWindowDurationSec() {
-        return aggregationWindowDurationSec;
+    public Integer getMaxAggregationWindowDurationDays() {
+        return maxAggregationWindowDurationDays;
+    }
+
+    public Integer getLoadTimeout() {
+        return loadTimeout;
+    }
+
+    public Integer getVertxWorkerPoolSize() {
+        return vertxWorkerPoolSize;
     }
 
     public DeploymentOptions getHttpVerticleConfig() {

--- a/userapi/src/main/java/fk/prof/userapi/Configuration.java
+++ b/userapi/src/main/java/fk/prof/userapi/Configuration.java
@@ -25,8 +25,8 @@ public class Configuration {
     @JsonProperty("max.list_profiles.duration.days")
     private Integer maxListProfilesDurationInDays = 7;
 
-    @JsonProperty("load.timeout")
-    private Integer loadTimeout = 10000;
+    @JsonProperty("profile.load.timeout")
+    private Integer profileLoadTimeout = 10000;
 
     @JsonProperty("vertx.worker.pool.size")
     private Integer vertxWorkerPoolSize;
@@ -61,8 +61,8 @@ public class Configuration {
         return maxListProfilesDurationInDays;
     }
 
-    public Integer getLoadTimeout() {
-        return loadTimeout;
+    public Integer getProfileLoadTimeout() {
+        return profileLoadTimeout;
     }
 
     public Integer getVertxWorkerPoolSize() {

--- a/userapi/src/main/java/fk/prof/userapi/Configuration.java
+++ b/userapi/src/main/java/fk/prof/userapi/Configuration.java
@@ -22,8 +22,8 @@ public class Configuration {
     @JsonProperty("profile.retention.duration.min")
     private Integer profileRetentionDurationMin = 30;
 
-    @JsonProperty("max.aggregation_window.duration.days")
-    private Integer maxAggregationWindowDurationDays = 7;
+    @JsonProperty("max.list_profiles.duration.days")
+    private Integer maxListProfilesDurationInDays = 7;
 
     @JsonProperty("load.timeout")
     private Integer loadTimeout = 10000;
@@ -57,8 +57,8 @@ public class Configuration {
         return profileRetentionDurationMin;
     }
 
-    public Integer getMaxAggregationWindowDurationDays() {
-        return maxAggregationWindowDurationDays;
+    public Integer getMaxListProfilesDurationInDays() {
+        return maxListProfilesDurationInDays;
     }
 
     public Integer getLoadTimeout() {

--- a/userapi/src/main/java/fk/prof/userapi/UserapiManager.java
+++ b/userapi/src/main/java/fk/prof/userapi/UserapiManager.java
@@ -77,7 +77,7 @@ public class UserapiManager {
         registerSerializers(Json.mapper);
         registerSerializers(Json.prettyMapper);
 
-        ProfileStoreAPI profileStoreAPI = new ProfileStoreAPIImpl(vertx, this.storage, config.getProfileRetentionDurationMin(), config.getLoadTimeout(), config.getVertxWorkerPoolSize());
+        ProfileStoreAPI profileStoreAPI = new ProfileStoreAPIImpl(vertx, this.storage, config.getProfileRetentionDurationMin(), config.getProfileLoadTimeout(), config.getVertxWorkerPoolSize());
         VerticleDeployer userapiHttpVerticleDeployer = new UserapiHttpVerticleDeployer(vertx, config, profileStoreAPI);
 
         userapiHttpVerticleDeployer.deploy().setHandler(verticleDeployCompositeResult -> {

--- a/userapi/src/main/java/fk/prof/userapi/UserapiManager.java
+++ b/userapi/src/main/java/fk/prof/userapi/UserapiManager.java
@@ -77,7 +77,7 @@ public class UserapiManager {
         registerSerializers(Json.mapper);
         registerSerializers(Json.prettyMapper);
 
-        ProfileStoreAPI profileStoreAPI = new ProfileStoreAPIImpl(vertx, this.storage, config.getProfileRetentionDurationMin());
+        ProfileStoreAPI profileStoreAPI = new ProfileStoreAPIImpl(vertx, this.storage, config.getProfileRetentionDurationMin(), config.getLoadTimeout(), config.getVertxWorkerPoolSize());
         VerticleDeployer userapiHttpVerticleDeployer = new UserapiHttpVerticleDeployer(vertx, config, profileStoreAPI);
 
         userapiHttpVerticleDeployer.deploy().setHandler(verticleDeployCompositeResult -> {

--- a/userapi/src/main/java/fk/prof/userapi/api/ProfileStoreAPIImpl.java
+++ b/userapi/src/main/java/fk/prof/userapi/api/ProfileStoreAPIImpl.java
@@ -114,8 +114,7 @@ public class ProfileStoreAPIImpl implements ProfileStoreAPI {
 
     @Override
     public void getProfilesInTimeWindow(Future<List<AggregatedProfileNamingStrategy>> profiles, String baseDir, String appId, String clusterId, String proc, ZonedDateTime startTime, int durationInSeconds) {
-        ZonedDateTime startTimes = ZonedDateTime.ofInstant(startTime.toInstant(), ZoneId.of("UTC"));
-        LocalDate startDate = startTimes.toLocalDate();
+        LocalDate startDate = ZonedDateTime.ofInstant(startTime.toInstant(), ZoneId.of("UTC")).toLocalDate();
         LocalDate endDate = ZonedDateTime.ofInstant(startTime.plusSeconds(durationInSeconds).toInstant(), ZoneId.of("UTC")).toLocalDate();
         LocalDate currentDate = startDate;
         String prefix = baseDir + DELIMITER + VERSION + DELIMITER + encode(appId)

--- a/userapi/src/main/java/fk/prof/userapi/api/ProfileStoreAPIImpl.java
+++ b/userapi/src/main/java/fk/prof/userapi/api/ProfileStoreAPIImpl.java
@@ -32,8 +32,8 @@ public class ProfileStoreAPIImpl implements ProfileStoreAPI {
 
     private static final String DELIMITER = "/";
     private static final String WORKER_POOL_NAME = "aggregation.loader.pool";
-    private final String VERSION = "v0001";
-    private final int loadTimeout;
+    private static final String VERSION = "v0001";
+    private final int profileLoadTimeout;
 
     private Vertx vertx;
     private AsyncStorage asyncStorage;
@@ -48,11 +48,11 @@ public class ProfileStoreAPIImpl implements ProfileStoreAPI {
     * is in progress, this map will contain its corresponding key */
     private Map<String, FuturesList<Object>> futuresForLoadingFiles;
 
-    public ProfileStoreAPIImpl(Vertx vertx, AsyncStorage asyncStorage, int maxIdleRetentionInMin, Integer loadTimeout, Integer workerPoolSize) {
+    public ProfileStoreAPIImpl(Vertx vertx, AsyncStorage asyncStorage, int maxIdleRetentionInMin, Integer profileLoadTimeout, Integer workerPoolSize) {
         this.vertx = vertx;
         this.asyncStorage = asyncStorage;
         this.profileLoader = new AggregatedProfileLoader(this.asyncStorage);
-        this.loadTimeout = loadTimeout;
+        this.profileLoadTimeout = profileLoadTimeout;
 
         this.workerExecutor = vertx.createSharedWorkerExecutor(WORKER_POOL_NAME, workerPoolSize);
 
@@ -157,7 +157,7 @@ public class ProfileStoreAPIImpl implements ProfileStoreAPI {
             // save the future, so that it can be notified when the loading visit finishes
             saveRequestedFuture(fileNameKey, future);
             // set the timeout for this future
-            vertx.setTimer(loadTimeout, timerId -> timeoutRequestedFuture(fileNameKey, future));
+            vertx.setTimer(profileLoadTimeout, timerId -> timeoutRequestedFuture(fileNameKey, future));
 
             if (!fileLoadInProgress) {
                 workerExecutor.executeBlocking((Future<AggregatedProfileInfo> f) -> profileLoader.load(f, filename),
@@ -185,7 +185,7 @@ public class ProfileStoreAPIImpl implements ProfileStoreAPI {
             // save the future, so that it can be notified when the loading visit finishes
             saveRequestedFuture(fileNameKey, future);
             // set the timeout for this future
-            vertx.setTimer(loadTimeout, timerId -> timeoutRequestedFuture(fileNameKey, future));
+            vertx.setTimer(profileLoadTimeout, timerId -> timeoutRequestedFuture(fileNameKey, future));
 
             if (!fileLoadInProgress) {
                 workerExecutor.executeBlocking((Future<AggregationWindowSummary> f) -> profileLoader.loadSummary(f, filename),

--- a/userapi/src/main/java/fk/prof/userapi/deployer/impl/UserapiHttpVerticleDeployer.java
+++ b/userapi/src/main/java/fk/prof/userapi/deployer/impl/UserapiHttpVerticleDeployer.java
@@ -26,6 +26,6 @@ public class UserapiHttpVerticleDeployer extends VerticleDeployer {
     @Override
     protected Verticle buildVerticle() {
         Configuration config = getConfig();
-        return new HttpVerticle(config.getHttpConfig(), profileStoreAPI, config.getProfilesBaseDir(), config.getAggregationWindowDurationSec());
+        return new HttpVerticle(config.getHttpConfig(), profileStoreAPI, config.getProfilesBaseDir(), config.getMaxAggregationWindowDurationDays());
     }
 }

--- a/userapi/src/main/java/fk/prof/userapi/deployer/impl/UserapiHttpVerticleDeployer.java
+++ b/userapi/src/main/java/fk/prof/userapi/deployer/impl/UserapiHttpVerticleDeployer.java
@@ -26,6 +26,6 @@ public class UserapiHttpVerticleDeployer extends VerticleDeployer {
     @Override
     protected Verticle buildVerticle() {
         Configuration config = getConfig();
-        return new HttpVerticle(config.getHttpConfig(), profileStoreAPI, config.getProfilesBaseDir(), config.getMaxAggregationWindowDurationDays());
+        return new HttpVerticle(config.getHttpConfig(), profileStoreAPI, config.getProfilesBaseDir(), config.getMaxListProfilesDurationInDays());
     }
 }

--- a/userapi/src/main/java/fk/prof/userapi/verticles/HttpVerticle.java
+++ b/userapi/src/main/java/fk/prof/userapi/verticles/HttpVerticle.java
@@ -40,15 +40,15 @@ public class HttpVerticle extends AbstractVerticle {
     private static Logger LOGGER = LoggerFactory.getLogger(HttpVerticle.class);
 
     private String baseDir;
-    private final int maxAggregationWindowDurationInDays;
+    private final int maxListProfilesDurationInSecs;
     private Configuration.HttpConfig httpConfig;
     private ProfileStoreAPI profileStoreAPI;
 
-    public HttpVerticle(Configuration.HttpConfig httpConfig, ProfileStoreAPI profileStoreAPI, String baseDir, int maxAggregationWindowDurationInDays) {
+    public HttpVerticle(Configuration.HttpConfig httpConfig, ProfileStoreAPI profileStoreAPI, String baseDir, int maxListProfilesDurationInDays) {
         this.httpConfig = httpConfig;
         this.profileStoreAPI = profileStoreAPI;
         this.baseDir = baseDir;
-        this.maxAggregationWindowDurationInDays = maxAggregationWindowDurationInDays;
+        this.maxListProfilesDurationInSecs = maxListProfilesDurationInDays*24*60*60;
     }
 
     private Router configureRouter() {
@@ -130,8 +130,8 @@ public class HttpVerticle extends AbstractVerticle {
             setResponse(Future.failedFuture(new IllegalArgumentException(e)), routingContext);
             return;
         }
-        if (duration > maxAggregationWindowDurationInDays*24*60*60) {
-            setResponse(Future.failedFuture(new IllegalArgumentException("Max window size supported = " + maxAggregationWindowDurationInDays*24*60*60 + " seconds, requested window size = " + duration + " seconds")), routingContext);
+        if (duration > maxListProfilesDurationInSecs) {
+            setResponse(Future.failedFuture(new IllegalArgumentException("Max window size supported = " + maxListProfilesDurationInSecs + " seconds, requested window size = " + duration + " seconds")), routingContext);
             return;
         }
 

--- a/userapi/src/main/java/fk/prof/userapi/verticles/HttpVerticle.java
+++ b/userapi/src/main/java/fk/prof/userapi/verticles/HttpVerticle.java
@@ -130,7 +130,7 @@ public class HttpVerticle extends AbstractVerticle {
             startTime = ZonedDateTime.parse(routingContext.request().getParam("start"), DateTimeFormatter.ISO_ZONED_DATE_TIME);
             duration = Integer.parseInt(routingContext.request().getParam("duration"));
             if (duration > MAX_TIME_WINDOW) { // Seconds in seven days
-                throw new RuntimeException("Max window size supported = " + MAX_TIME_WINDOW + " seconds, requested window size = " + duration + " seconds");
+                throw new IllegalArgumentException("Max window size supported = " + MAX_TIME_WINDOW + " seconds, requested window size = " + duration + " seconds");
             }
         } catch (Exception e) {
             setResponse(Future.failedFuture(new IllegalArgumentException(e)), routingContext);
@@ -271,13 +271,7 @@ public class HttpVerticle extends AbstractVerticle {
     private AggregatedProfileNamingStrategy buildFileName(String appId, String clusterId, String procId,
                                                           AggregatedProfileModel.WorkType workType, String startTime, String duration) {
         ZonedDateTime zonedStartTime = ZonedDateTime.parse(startTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
-        int windowDuration;
-        try {
-            windowDuration = Integer.parseInt(duration);
-        } catch (Exception e) {
-            windowDuration = aggregationWindowDurationInSecs;
-        }
-        return new AggregatedProfileNamingStrategy(baseDir, 1, appId, clusterId, procId, zonedStartTime, windowDuration, workType);
+        return new AggregatedProfileNamingStrategy(baseDir, 1, appId, clusterId, procId, zonedStartTime, Integer.parseInt(duration), workType);
     }
 
     private boolean safeContains(String str, String subStr) {

--- a/userapi/src/test/java/fk/prof/userapi/model/ParseProfileTest.java
+++ b/userapi/src/test/java/fk/prof/userapi/model/ParseProfileTest.java
@@ -69,7 +69,7 @@ public class ParseProfileTest {
         vertx = Vertx.vertx();
         asyncStorage = mock(AsyncStorage.class);
         config = UserapiConfigManager.loadConfig(ParseProfileTest.class.getClassLoader().getResource("userapi-conf.json").getFile());
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getProfileLoadTimeout(), config.getVertxWorkerPoolSize());
     }
 
     @After
@@ -92,7 +92,7 @@ public class ParseProfileTest {
             throw new ObjectNotFoundException("not found");
         }));
 
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, storage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, storage, 30, config.getProfileLoadTimeout(), config.getVertxWorkerPoolSize());
 
         Future<AggregatedProfileInfo> future1 = Future.future();
         Future<AggregatedProfileInfo> future2 = Future.future();

--- a/userapi/src/test/java/fk/prof/userapi/model/ParseProfileTest.java
+++ b/userapi/src/test/java/fk/prof/userapi/model/ParseProfileTest.java
@@ -7,7 +7,9 @@ import fk.prof.aggregation.serialize.Serializer;
 import fk.prof.storage.AsyncStorage;
 import fk.prof.storage.ObjectNotFoundException;
 import fk.prof.storage.S3AsyncStorage;
+import fk.prof.userapi.Configuration;
 import fk.prof.userapi.Deserializer;
+import fk.prof.userapi.UserapiConfigManager;
 import fk.prof.userapi.api.ProfileStoreAPI;
 import fk.prof.userapi.api.ProfileStoreAPIImpl;
 import fk.prof.userapi.model.json.ProtoSerializers;
@@ -47,6 +49,7 @@ public class ParseProfileTest {
 
     final String traceName1 = "print-trace-1";
     final String traceName2 = "doSome-trace-2";
+    private Configuration config;
 
     @Test
     public void testReadWriteForVariant() throws Exception {
@@ -62,10 +65,11 @@ public class ParseProfileTest {
     }
 
     @Before
-    public void testSetUp(TestContext context) {
+    public void testSetUp(TestContext context) throws Exception{
         vertx = Vertx.vertx();
         asyncStorage = mock(AsyncStorage.class);
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30);
+        config = UserapiConfigManager.loadConfig(ParseProfileTest.class.getClassLoader().getResource("userapi-conf.json").getFile());
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
     }
 
     @After
@@ -88,7 +92,7 @@ public class ParseProfileTest {
             throw new ObjectNotFoundException("not found");
         }));
 
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, storage, 30);
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, storage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
 
         Future<AggregatedProfileInfo> future1 = Future.future();
         Future<AggregatedProfileInfo> future2 = Future.future();

--- a/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
+++ b/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
@@ -85,7 +85,7 @@ public class ProfileDiscoveryAPITest {
         vertx = Vertx.vertx();
         asyncStorage = mock(AsyncStorage.class);
         config = UserapiConfigManager.loadConfig(ParseProfileTest.class.getClassLoader().getResource("userapi-conf.json").getFile());
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getProfileLoadTimeout(), config.getVertxWorkerPoolSize());
 
         when(asyncStorage.listAsync(anyString(), anyBoolean())).thenAnswer(invocation -> {
             String path1 = invocation.getArgument(0);

--- a/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
+++ b/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
@@ -1,7 +1,6 @@
 package fk.prof.userapi.model;
 
 import fk.prof.aggregation.AggregatedProfileNamingStrategy;
-import fk.prof.aggregation.proto.AggregatedProfileModel;
 import fk.prof.storage.AsyncStorage;
 import fk.prof.userapi.api.ProfileStoreAPI;
 import fk.prof.userapi.api.ProfileStoreAPIImpl;
@@ -22,7 +21,6 @@ import org.mockito.internal.util.collections.Sets;
 
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 

--- a/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
+++ b/userapi/src/test/java/fk/prof/userapi/model/ProfileDiscoveryAPITest.java
@@ -2,6 +2,8 @@ package fk.prof.userapi.model;
 
 import fk.prof.aggregation.AggregatedProfileNamingStrategy;
 import fk.prof.storage.AsyncStorage;
+import fk.prof.userapi.Configuration;
+import fk.prof.userapi.UserapiConfigManager;
 import fk.prof.userapi.api.ProfileStoreAPI;
 import fk.prof.userapi.api.ProfileStoreAPIImpl;
 import fk.prof.userapi.model.json.ProtoSerializers;
@@ -56,6 +58,7 @@ public class ProfileDiscoveryAPITest {
     };
 
     AggregatedProfileNamingStrategy[] filenames = Stream.of(objects).map(AggregatedProfileNamingStrategy::fromFileName).toArray(AggregatedProfileNamingStrategy[]::new);
+    private Configuration config;
 
     private Set<String> getObjList(String prefix, boolean recursive) {
 
@@ -81,7 +84,8 @@ public class ProfileDiscoveryAPITest {
     public void setUp() throws Exception {
         vertx = Vertx.vertx();
         asyncStorage = mock(AsyncStorage.class);
-        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30);
+        config = UserapiConfigManager.loadConfig(ParseProfileTest.class.getClassLoader().getResource("userapi-conf.json").getFile());
+        profileDiscoveryAPI = new ProfileStoreAPIImpl(vertx, asyncStorage, 30, config.getLoadTimeout(), config.getVertxWorkerPoolSize());
 
         when(asyncStorage.listAsync(anyString(), anyBoolean())).thenAnswer(invocation -> {
             String path1 = invocation.getArgument(0);

--- a/userapi/src/test/java/fk/prof/userapi/verticles/RouterVerticleTest.java
+++ b/userapi/src/test/java/fk/prof/userapi/verticles/RouterVerticleTest.java
@@ -24,13 +24,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.net.ServerSocket;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -72,8 +70,6 @@ public class RouterVerticleTest {
     private Vertx vertx;
     private HttpClient client;
     private int port = 8082;
-    @InjectMocks
-    private HttpVerticle routerVerticle;
 
     @Mock
     private ProfileStoreAPIImpl profileDiscoveryAPI;
@@ -81,10 +77,6 @@ public class RouterVerticleTest {
     @Before
     public void setUp(TestContext testContext) throws Exception {
         ProtoSerializers.registerSerializers(Json.mapper);
-
-        ServerSocket socket = new ServerSocket(0);
-        port = socket.getLocalPort();
-        socket.close();
 
         UserapiConfigManager.setDefaultSystemProperties();
         Configuration config = UserapiConfigManager.loadConfig(ProfileStoreAPIImpl.class.getClassLoader().getResource("userapi-conf.json").getFile());

--- a/userapi/src/test/resources/userapi-conf.json
+++ b/userapi/src/test/resources/userapi-conf.json
@@ -7,7 +7,7 @@
     }
   },
   "profile.retention.duration.min": 30,
-  "aggregation_window.duration.secs": 1800,
+  "load.timeout": 10000,
   "storage": {
     "s3": {
       "endpoint": "http://127.0.0.1:13031",
@@ -22,5 +22,6 @@
       "queue.maxsize": 50
     }
   },
-  "aggregatedProfiles.baseDir": "profiles"
+  "aggregatedProfiles.baseDir": "profiles",
+  "vertx.worker.pool.size": 50
 }

--- a/userapi/src/test/resources/userapi-conf.json
+++ b/userapi/src/test/resources/userapi-conf.json
@@ -7,7 +7,7 @@
     }
   },
   "profile.retention.duration.min": 30,
-  "load.timeout": 10000,
+  "profile.load.timeout": 10000,
   "storage": {
     "s3": {
       "endpoint": "http://127.0.0.1:13031",

--- a/userapi/src/test/resources/userapi-conf.json
+++ b/userapi/src/test/resources/userapi-conf.json
@@ -12,14 +12,15 @@
     "s3": {
       "endpoint": "http://127.0.0.1:13031",
       "access.key": "",
-      "secret.key": ""
+      "secret.key": "",
+      "list.objects.timeout.ms": 1000
     },
     "thread.pool": {
       "coresize": 10,
       "maxsize": 50,
       "idletime.secs": 60,
       "queue.maxsize": 50
-    },
-    "base.dir": "profiles"
-  }
+    }
+  },
+  "aggregatedProfiles.baseDir": "profiles"
 }


### PR DESCRIPTION
- Added date in prefix while making getProfilesInTimeWindow call to filter out non-required profileFileNames
- Added maxTimeWindow check in getProfiles route handler to avoid abuse.
- Added a mandatory requirement of duration param in getCpuSamplingTraces handler
- Made change in UI to send duration in the URL param along with start time while requesting for a profile.