### PR TITLE
Fetch all associations API and delay in setting up of first aggregation window

### DIFF
--- a/backend/src/main/java/fk/prof/backend/http/ApiPathConstants.java
+++ b/backend/src/main/java/fk/prof/backend/http/ApiPathConstants.java
@@ -10,8 +10,10 @@ public final class ApiPathConstants {
   public static final String LEADER_GET_WORK = "/leader/work";
   public static final String LEADER_POST_ASSOCIATION = "/leader/association";
   public static final String LEADER_POST_POLICY = "/leader/policy";
+  public static final String LEADER_GET_ASSOCIATIONS = "/leader/associations";
 
   public static final String BACKEND_POST_ASSOCIATION = "/association";
+  public static final String BACKEND_GET_ASSOCIATIONS = "/associations";
   public static final String BACKEND_POST_POLL = "/poll";
   public static final String BACKEND_HEALTHCHECK = "/health";
 }

--- a/backend/src/main/java/fk/prof/backend/http/LeaderHttpVerticle.java
+++ b/backend/src/main/java/fk/prof/backend/http/LeaderHttpVerticle.java
@@ -63,6 +63,9 @@ public class LeaderHttpVerticle extends AbstractVerticle {
     HttpHelper.attachHandlersToRoute(router, HttpMethod.POST, ApiPathConstants.LEADER_POST_ASSOCIATION,
         BodyHandler.create().setBodyLimit(1024 * 10), this::handlePostAssociation);
 
+    HttpHelper.attachHandlersToRoute(router, HttpMethod.GET, ApiPathConstants.LEADER_GET_ASSOCIATIONS,
+        this::handleGetAssociations);
+
     String apiPathForGetWork = ApiPathConstants.LEADER_GET_WORK + "/:appId/:clusterId/:procName";
     HttpHelper.attachHandlersToRoute(router, HttpMethod.GET, apiPathForGetWork,
         BodyHandler.create().setBodyLimit(1024 * 100), this::handleGetWork);
@@ -197,6 +200,15 @@ public class LeaderHttpVerticle extends AbstractVerticle {
       context.response().end();
     }
     catch (Exception ex) {
+      HttpFailure httpFailure = HttpFailure.failure(ex);
+      HttpHelper.handleFailure(context, httpFailure);
+    }
+  }
+
+  private void handleGetAssociations(RoutingContext context) {
+    try {
+      context.response().end(ProtoUtil.buildBufferFromProto(backendAssociationStore.getAssociations()));
+    } catch (Exception ex) {
       HttpFailure httpFailure = HttpFailure.failure(ex);
       HttpHelper.handleFailure(context, httpFailure);
     }

--- a/backend/src/main/java/fk/prof/backend/model/assignment/AggregationWindowPlanner.java
+++ b/backend/src/main/java/fk/prof/backend/model/assignment/AggregationWindowPlanner.java
@@ -46,6 +46,7 @@ public class AggregationWindowPlanner {
   private final Recorder.ProcessGroup processGroup;
   private final int aggregationWindowDurationInSecs;
   private final int policyRefreshBufferInSecs;
+  private final long aggregationWindowStartupTimer;
   private final Future<Long> aggregationWindowScheduleTimer;
 
   private AggregationWindow currentAggregationWindow = null;
@@ -65,6 +66,7 @@ public class AggregationWindowPlanner {
                                   int backendId,
                                   int aggregationWindowDurationInSecs,
                                   int policyRefreshBufferInSecs,
+                                  int thresholdForDefunctRecorderInSecs,
                                   WorkAssignmentScheduleBootstrapConfig workAssignmentScheduleBootstrapConfig,
                                   WorkSlotPool workSlotPool,
                                   ProcessGroupContextForScheduling processGroupContextForScheduling,
@@ -100,18 +102,20 @@ public class AggregationWindowPlanner {
     this.mtrWindowExpireFailure = metricRegistry.meter(MetricRegistry.name(MetricName.AW_Expire_Failure.get(), processGroupStr));
 
     this.aggregationWindowScheduleTimer = Future.future();
-    getWorkForNextAggregationWindow(currentAggregationWindowIndex + 1).setHandler(ar -> {
-      aggregationWindowSwitcher();
+    this.aggregationWindowStartupTimer = vertx.setTimer(thresholdForDefunctRecorderInSecs * MILLIS_IN_SEC, tId -> {
+      getWorkForNextAggregationWindow(currentAggregationWindowIndex + 1).setHandler(ar -> {
+        aggregationWindowSwitcher();
 
-      // From vertx docs:
-      // Keep in mind that the timer will fire on a periodic basis.
-      // If your periodic treatment takes a long amount of time to proceed, your timer events could run continuously or even worse : stack up.
-      // NOTE: The above is a fringe scenario since aggregation window duration is going to be in excess of 20 minutes
-      // Still, there is a way to detect if this build-up happens. If aggregation window switch event happens before work profile is fetched, we publish a metric
-      // If /leader/work API latency is within bounds but this metric is high, this implies a build-up of aggregation window events
-      long periodicTimerId = vertx.setPeriodic(aggregationWindowDurationInSecs * MILLIS_IN_SEC,
-          timerId -> aggregationWindowSwitcher());
-      this.aggregationWindowScheduleTimer.complete(periodicTimerId);
+        // From vertx docs:
+        // Keep in mind that the timer will fire on a periodic basis.
+        // If your periodic treatment takes a long amount of time to proceed, your timer events could run continuously or even worse : stack up.
+        // NOTE: The above is a fringe scenario since aggregation window duration is going to be in excess of 20 minutes
+        // Still, there is a way to detect if this build-up happens. If aggregation window switch event happens before work profile is fetched, we publish a metric
+        // If /leader/work API latency is within bounds but this metric is high, this implies a build-up of aggregation window events
+        long periodicTimerId = vertx.setPeriodic(aggregationWindowDurationInSecs * MILLIS_IN_SEC,
+            timerId -> aggregationWindowSwitcher());
+        this.aggregationWindowScheduleTimer.complete(periodicTimerId);
+      });
     });
   }
 
@@ -120,6 +124,7 @@ public class AggregationWindowPlanner {
    * To be called when leader de-associates relevant process group from the backend
    */
   public void close() {
+    vertx.cancelTimer(aggregationWindowStartupTimer);
     aggregationWindowScheduleTimer.setHandler(ar -> {
       if(ar.succeeded()) {
         vertx.cancelTimer(ar.result());

--- a/backend/src/main/java/fk/prof/backend/model/assignment/AggregationWindowPlannerStore.java
+++ b/backend/src/main/java/fk/prof/backend/model/assignment/AggregationWindowPlannerStore.java
@@ -27,12 +27,14 @@ public class AggregationWindowPlannerStore {
   private final WorkAssignmentScheduleBootstrapConfig workAssignmentScheduleBootstrapConfig;
   private final int aggregationWindowDurationInSecs;
   private final int policyRefreshBufferInSecs;
+  private final int thresholdForDefunctRecorderInSecs;
 
   public AggregationWindowPlannerStore(Vertx vertx,
                                        int backendId,
                                        int windowDurationInSecs,
                                        int windowEndToleranceInSecs,
                                        int policyRefreshBufferInSecs,
+                                       int thresholdForDefunctRecorderInSecs,
                                        int schedulingBufferInSecs,
                                        int maxAcceptableDelayForWorkAssignmentInSecs,
                                        WorkSlotPool workSlotPool,
@@ -51,6 +53,7 @@ public class AggregationWindowPlannerStore {
         maxAcceptableDelayForWorkAssignmentInSecs);
     this.aggregationWindowDurationInSecs = windowDurationInSecs;
     this.policyRefreshBufferInSecs = policyRefreshBufferInSecs;
+    this.thresholdForDefunctRecorderInSecs = thresholdForDefunctRecorderInSecs;
   }
 
   /**
@@ -64,6 +67,7 @@ public class AggregationWindowPlannerStore {
           backendId,
           aggregationWindowDurationInSecs,
           policyRefreshBufferInSecs,
+          thresholdForDefunctRecorderInSecs,
           workAssignmentScheduleBootstrapConfig,
           workSlotPool,
           processGroupContextForScheduling,

--- a/backend/src/main/java/fk/prof/backend/model/association/BackendAssociationStore.java
+++ b/backend/src/main/java/fk/prof/backend/model/association/BackendAssociationStore.java
@@ -8,6 +8,7 @@ public interface BackendAssociationStore {
   Future<Recorder.ProcessGroups> reportBackendLoad(BackendDTO.LoadReportRequest payload);
   Future<Recorder.AssignedBackend> associateAndGetBackend(Recorder.ProcessGroup processGroup);
   Recorder.AssignedBackend getAssociatedBackend(Recorder.ProcessGroup processGroup);
+  Recorder.BackendAssociations getAssociations();
 
   /**
    * Method to allow delayed initialization. Calling other methods before init may result in undefined behaviour.

--- a/backend/src/main/java/fk/prof/backend/model/association/impl/ZookeeperBasedBackendAssociationStore.java
+++ b/backend/src/main/java/fk/prof/backend/model/association/impl/ZookeeperBasedBackendAssociationStore.java
@@ -294,6 +294,17 @@ public class ZookeeperBasedBackendAssociationStore implements BackendAssociation
   }
 
   @Override
+  public Recorder.BackendAssociations getAssociations() {
+    Recorder.BackendAssociations.Builder builder = Recorder.BackendAssociations.newBuilder();
+    this.backendDetailLookup.entrySet().forEach(backendEntry ->
+      builder.addAssociations(
+          Recorder.BackendAssociation.newBuilder()
+              .setBackend(backendEntry.getKey())
+              .addAllProcessGroups(backendEntry.getValue().getAssociatedProcessGroups())));
+    return builder.build();
+  }
+
+  @Override
   public void init() throws Exception {
     synchronized (this) {
       if(!initialized) {

--- a/backend/src/main/java/fk/prof/backend/worker/BackendDaemon.java
+++ b/backend/src/main/java/fk/prof/backend/worker/BackendDaemon.java
@@ -93,6 +93,7 @@ public class BackendDaemon extends AbstractVerticle {
         daemonConfig.getAggrWindowDurationSecs(),
         daemonConfig.getAggrWindowEndToleranceSecs(),
         daemonConfig.getPolicyRefreshOffsetSecs(),
+        config.getRecorderDefunctThresholdSecs(),
         daemonConfig.getSchedulingBufferSecs(),
         daemonConfig.getWorkAssignmentMaxDelaySecs(),
         workSlotPool,

--- a/backend/src/test/java/fk/prof/backend/AssociationApiTest.java
+++ b/backend/src/test/java/fk/prof/backend/AssociationApiTest.java
@@ -35,6 +35,9 @@ import recording.Recorder;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -66,7 +69,7 @@ public class AssociationApiTest {
     curatorClient.blockUntilConnected(10, TimeUnit.SECONDS);
     curatorClient.create().forPath(backendAssociationPath);
 
-    config = ConfigManager.loadConfig(AssociationApiTest.class.getClassLoader().getResource("config.json").getFile());
+    config = spy(ConfigManager.loadConfig(AssociationApiTest.class.getClassLoader().getResource("config.json").getFile()));
     vertx = Vertx.vertx(new VertxOptions(config.getVertxOptions()));
     port = config.getBackendHttpServerOpts().getPort();
     leaderPort = config.getLeaderHttpServerOpts().getPort();
@@ -219,6 +222,71 @@ public class AssociationApiTest {
     });
   }
 
+  @Test(timeout = 20000)
+  public void getAllAssociationsProxiedToLeader(TestContext context) throws InterruptedException {
+    final Async async = context.async();
+
+    VerticleDeployer leaderHttpDeployer = new LeaderHttpVerticleDeployer(vertx, config, backendAssociationStore, policyStore);
+    Runnable leaderElectedTask = LeaderElectedTask.newBuilder().build(vertx, leaderHttpDeployer, backendAssociationStore, policyStore);
+
+    VerticleDeployer leaderParticipatorDeployer = new LeaderElectionParticipatorVerticleDeployer(vertx, config, curatorClient, leaderElectedTask);
+    VerticleDeployer leaderWatcherDeployer = new LeaderElectionWatcherVerticleDeployer(vertx, config, curatorClient, inMemoryLeaderStore);
+    CompositeFuture.all(leaderParticipatorDeployer.deploy(), leaderWatcherDeployer.deploy()).setHandler(deployResult -> {
+      if(deployResult.failed()) {
+        context.fail(deployResult.cause());
+      }
+
+      try {
+        //This sleep should be enough for leader store to get updated with the new leader and leader elected task to be executed
+        Thread.sleep(5000);
+        when(inMemoryLeaderStore.isLeader()).thenReturn(false);
+
+        Future<ProfHttpClient.ResponseWithStatusTuple> r1 = makeRequestReportLoad(BackendDTO.LoadReportRequest.newBuilder().setIp("1").setPort(1).setLoad(0.5f).setCurrTick(2).build());
+        Future<ProfHttpClient.ResponseWithStatusTuple> r2 = makeRequestReportLoad(BackendDTO.LoadReportRequest.newBuilder().setIp("2").setPort(1).setLoad(0.5f).setCurrTick(2).build());
+        CompositeFuture.all(r1, r2).setHandler(ar -> {
+          if(ar.failed()) {
+            context.fail(ar.cause());
+          }
+          try {
+            Recorder.ProcessGroup.Builder pgBuilder = Recorder.ProcessGroup.newBuilder().setAppId("a").setCluster("c");
+            Recorder.ProcessGroup pg1 = pgBuilder.clone().setProcName("p1").build();
+            Recorder.ProcessGroup pg2 = pgBuilder.clone().setProcName("p2").build();
+            Recorder.ProcessGroup pg3 = pgBuilder.clone().setProcName("p3").build();
+            Future<ProfHttpClient.ResponseWithStatusTuple> r3 = makeRequestPostAssociation(buildRecorderInfoFromProcessGroup(pg1));
+            Future<ProfHttpClient.ResponseWithStatusTuple> r4 = makeRequestPostAssociation(buildRecorderInfoFromProcessGroup(pg2));
+            Future<ProfHttpClient.ResponseWithStatusTuple> r5 = makeRequestPostAssociation(buildRecorderInfoFromProcessGroup(pg3));
+
+            CompositeFuture.all(r3, r4, r5).setHandler(ar1 -> {
+              if(ar1.failed()) {
+                context.fail(ar1.cause());
+              }
+              try {
+                makeRequestGetAssociations().setHandler(ar2 -> {
+                  if(ar2.failed()) {
+                    context.fail(ar2.cause());
+                  }
+                  try {
+                    context.assertEquals(200, ar2.result().getStatusCode());
+                    async.complete();
+                  } catch (Exception ex3) {
+                    context.fail(ex3);
+                  }
+                });
+              } catch (Exception ex2) {
+                context.fail(ex2);
+              }
+            });
+
+          } catch (Exception ex1) {
+            context.fail(ex1);
+          }
+        });
+      } catch (Exception ex) {
+        context.fail(ex);
+      }
+    });
+  }
+
   private Future<ProfHttpClient.ResponseWithStatusTuple> makeRequestPostAssociation(Recorder.RecorderInfo payload)
     throws IOException {
     Future<ProfHttpClient.ResponseWithStatusTuple> future = Future.future();
@@ -227,13 +295,31 @@ public class AssociationApiTest {
         .handler(response -> {
           response.bodyHandler(buffer -> {
             try {
-              future.complete(ProfHttpClient.ResponseWithStatusTuple.of(response.statusCode(),buffer));
+              future.complete(ProfHttpClient.ResponseWithStatusTuple.of(response.statusCode(), buffer));
             } catch (Exception ex) {
               future.fail(ex);
             }
           });
         }).exceptionHandler(ex -> future.fail(ex));
     request.end(ProtoUtil.buildBufferFromProto(payload));
+    return future;
+  }
+
+  private Future<ProfHttpClient.ResponseWithStatusTuple> makeRequestGetAssociations()
+      throws IOException {
+    Future<ProfHttpClient.ResponseWithStatusTuple> future = Future.future();
+    HttpClientRequest request = vertx.createHttpClient()
+        .get(port, "localhost", "/associations")
+        .handler(response -> {
+          response.bodyHandler(buffer -> {
+            try {
+              future.complete(ProfHttpClient.ResponseWithStatusTuple.of(response.statusCode(), buffer));
+            } catch (Exception ex) {
+              future.fail(ex);
+            }
+          });
+        }).exceptionHandler(ex -> future.fail(ex));
+    request.end();
     return future;
   }
 

--- a/backend/src/test/java/fk/prof/backend/HealthAPITest.java
+++ b/backend/src/test/java/fk/prof/backend/HealthAPITest.java
@@ -79,13 +79,14 @@ public class HealthAPITest {
     vertx = Vertx.vertx(new VertxOptions(config.getVertxOptions()));
     inMemoryLeaderStore = spy(new InMemoryLeaderStore(config.getIpAddress(), config.getLeaderHttpServerOpts().getPort()));
     VerticleDeployer backendHttpVerticleDeployer = new BackendHttpVerticleDeployer(vertx, config, inMemoryLeaderStore, new ActiveAggregationWindowsImpl(), mock(AssociatedProcessGroups.class));
-    backendHttpVerticleDeployer.deploy();
-    getHealthRequest().setHandler(ar -> {
-      if(ar.failed()) {
-        context.fail(ar.cause());
-      }
-      context.assertEquals(200, ar.result().getStatusCode());
-      async.complete();
+    backendHttpVerticleDeployer.deploy().setHandler(ar1 -> {
+      getHealthRequest().setHandler(ar -> {
+        if(ar.failed()) {
+          context.fail(ar.cause());
+        }
+        context.assertEquals(200, ar.result().getStatusCode());
+        async.complete();
+      });
     });
   }
 

--- a/backend/src/test/java/fk/prof/backend/LeaderElectionTest.java
+++ b/backend/src/test/java/fk/prof/backend/LeaderElectionTest.java
@@ -201,7 +201,7 @@ public class LeaderElectionTest {
     CompositeFuture f = populateAssociationAndPolicies(pg1, pg2, policy);
     f.setHandler(res -> {
       if(res.failed()) {
-        context.fail("failed to populate policies and associations. Reason: " + res.cause().toString());
+        context.fail(res.cause());
       }
       else {
         CompositeFuture cf =  res.result();

--- a/backend/src/test/java/fk/prof/backend/ZookeeperBasedBackendAssociationStoreTest.java
+++ b/backend/src/test/java/fk/prof/backend/ZookeeperBasedBackendAssociationStoreTest.java
@@ -128,6 +128,47 @@ public class ZookeeperBasedBackendAssociationStoreTest {
   }
 
   @Test(timeout = 10000)
+  public void testGetOfAllAssociations(TestContext context) {
+    final Async async = context.async();
+    Future<Recorder.ProcessGroups> f1 = backendAssociationStore.reportBackendLoad(
+        BackendDTO.LoadReportRequest.newBuilder().setIp("1").setPort(1).setLoad(0.1f).setCurrTick(1).build());
+    Future<Recorder.ProcessGroups> f2 = backendAssociationStore.reportBackendLoad(
+        BackendDTO.LoadReportRequest.newBuilder().setIp("2").setPort(1).setLoad(0.2f).setCurrTick(1).build());
+    CompositeFuture.all(Arrays.asList(f1, f2)).setHandler(ar1 -> {
+      if (ar1.failed()) {
+        context.fail(ar1.cause());
+      } else {
+        Future<Recorder.AssignedBackend> f3 = backendAssociationStore.associateAndGetBackend(mockProcessGroups.get(0));
+        Future<Recorder.AssignedBackend> f4 = backendAssociationStore.associateAndGetBackend(mockProcessGroups.get(1));
+        Future<Recorder.AssignedBackend> f5 = backendAssociationStore.associateAndGetBackend(mockProcessGroups.get(2));
+        CompositeFuture.all(Arrays.asList(f3, f4, f5)).setHandler(ar2 -> {
+          if (ar2.failed()) {
+            context.fail(ar2.cause());
+          } else {
+            Recorder.BackendAssociations associations = backendAssociationStore.getAssociations();
+            Set<Recorder.ProcessGroup> expectedPGs = new HashSet<>(Arrays.asList(mockProcessGroups.get(0), mockProcessGroups.get(1), mockProcessGroups.get(2)));
+            Set<Recorder.ProcessGroup> actualPGs = new HashSet<>();
+            int actualPGCount = 0;
+            Set<String> expectedIPs = new HashSet<>(Arrays.asList("1", "2"));
+            Set<String> actualIPs = new HashSet<>();
+            for (Recorder.BackendAssociation backendAssociation: associations.getAssociationsList()) {
+              actualIPs.add(backendAssociation.getBackend().getHost());
+              for (Recorder.ProcessGroup processGroup: backendAssociation.getProcessGroupsList()) {
+                actualPGCount++;
+                actualPGs.add(processGroup);
+              }
+            }
+            context.assertEquals(expectedIPs, actualIPs);
+            context.assertEquals(expectedPGs, actualPGs);
+            context.assertEquals(expectedPGs.size(), actualPGCount); //asserting counts because actualPGs is a set and de-duplication can happen so just asserting equality of sets is not sufficient here
+            async.complete();
+          }
+        });
+      }
+    });
+  }
+
+  @Test(timeout = 10000)
   public void testReloadOfAssociationsFromZK(TestContext context) {
     final Async async = context.async();
     Future<Recorder.ProcessGroups> f1 = backendAssociationStore.reportBackendLoad(

--- a/backend/src/test/resources/config.json
+++ b/backend/src/test/resources/config.json
@@ -81,7 +81,7 @@
       "queue.maxsize": 50
     }
   },
-  "bufferPoolOptions" : {
+  "bufferPoolOptions": {
     "max.total": 20,
     "max.idle": 20,
     "buffer.size": 10000000

--- a/recorder/src/idl/recorder.proto
+++ b/recorder/src/idl/recorder.proto
@@ -218,3 +218,12 @@ message ProcessGroup {
 message ProcessGroups {
   repeated ProcessGroup processGroup = 1;
 }
+
+message BackendAssociation {
+  required AssignedBackend backend = 1;
+  repeated ProcessGroup processGroups = 2;
+}
+
+message BackendAssociations {
+  repeated BackendAssociation associations = 1;
+}


### PR DESCRIPTION
Delay of recorder defunct threshold added for first window to avoid skip of first window because of unhealthy recorders
/leader/associations -> list of all backend->recorder associations, protobuf response
/associations -> proxies from backend to leader, json response