### PR TITLE
Error backtrace fix for frame-pointer omitted code

### DIFF
--- a/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
+++ b/e2etest/src/test/java/fk/prof/recorder/WorkHandlingTest.java
@@ -17,7 +17,6 @@ import recording.Recorder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -200,7 +199,7 @@ public class WorkHandlingTest {
         PollReqWithTime pollReqs[] = new PollReqWithTime[poll.length];
         poll[0] = tellRecorderWeHaveNoWork(pollReqs, 0);
         String cpuSamplingWorkIssueTime = ISODateTimeFormat.dateTime().print(DateTime.now());
-        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES);
+        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES, true);
         for (int i = 2; i < poll.length; i++) {
             poll[i] = tellRecorderWeHaveNoWork(pollReqs, i);
         }
@@ -284,7 +283,7 @@ public class WorkHandlingTest {
         PollReqWithTime pollReqs[] = new PollReqWithTime[poll.length];
         poll[0] = tellRecorderWeHaveNoWork(pollReqs, 0);
         String cpuSamplingWorkIssueTime = ISODateTimeFormat.dateTime().print(DateTime.now());
-        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES);
+        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES, true);
         for (int i = 2; i < poll.length; i++) {
             poll[i] = tellRecorderWeHaveNoWork(pollReqs, i);
         }
@@ -331,7 +330,7 @@ public class WorkHandlingTest {
         PollReqWithTime pollReqs[] = new PollReqWithTime[poll.length];
         poll[0] = tellRecorderWeHaveNoWork(pollReqs, 0);
         String cpuSamplingWorkIssueTime = ISODateTimeFormat.dateTime().print(DateTime.now());
-        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES);
+        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES, true);
         for (int i = 2; i < poll.length; i++) {
             poll[i] = tellRecorderWeHaveNoWork(pollReqs, i);
         }
@@ -387,7 +386,7 @@ public class WorkHandlingTest {
         PollReqWithTime pollReqs[] = new PollReqWithTime[poll.length];
         poll[0] = tellRecorderWeHaveNoWork(pollReqs, 0);
         String cpuSamplingWorkIssueTime = ISODateTimeFormat.dateTime().print(DateTime.now());
-        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES);
+        poll[1] = issueCpuProfilingWork(pollReqs, 1, 10, 2, cpuSamplingWorkIssueTime, CPU_SAMPLING_WORK_ID, CPU_SAMPLING_MAX_FRAMES, true);
         for (int i = 2; i < poll.length; i++) {
             poll[i] = tellRecorderWeHaveNoWork(pollReqs, i);
         }
@@ -506,13 +505,14 @@ public class WorkHandlingTest {
         assertWorkStateAndResultIs("UNKNOWN", workLastIssued, expectedId, state, result, elapsedTime);
     }
 
-    public static Function<byte[], byte[]> issueCpuProfilingWork(PollReqWithTime[] pollReqs, int idx, final int duration, final int delay, final String issueTime, final int workId, final int cpuSamplingMaxFrames) {
+    public static Function<byte[], byte[]> issueCpuProfilingWork(PollReqWithTime[] pollReqs, int idx, final int duration, final int delay, final String issueTime, final int workId, final int cpuSamplingMaxFrames, final boolean captureErrorBt) {
         return cookPollResponse(pollReqs, idx, (nowString, builder) -> {
             Recorder.WorkAssignment.Builder workAssignmentBuilder = prepareWorkAssignment(nowString, builder, delay, duration, CPU_SAMPLING_WORK_DESCRIPTION, workId);
             Recorder.Work.Builder workBuilder = workAssignmentBuilder.addWorkBuilder();
             workBuilder.setWType(Recorder.WorkType.cpu_sample_work).getCpuSampleBuilder()
                     .setFrequency(CPU_SAMPLING_FREQ)
-                    .setMaxFrames(cpuSamplingMaxFrames);
+                    .setMaxFrames(cpuSamplingMaxFrames)
+                    .setCaptureErrorBt(captureErrorBt);
         }, issueTime);
     }
 

--- a/e2etest/src/test/java/fk/prof/recorder/main/AllocBurner.java
+++ b/e2etest/src/test/java/fk/prof/recorder/main/AllocBurner.java
@@ -6,7 +6,7 @@ package fk.prof.recorder.main;
 public class AllocBurner {
     public static void main(String[] args) {
         for (int i = 0; i < 10; i++) {
-            GcBench.runBenchmark(120, 100, GcBench.kArraySize, GcBench.kMinTreeDepth, GcBench.kMaxTreeDepth);
+            GcBench.runBenchmark(200, 100, GcBench.kArraySize, GcBench.kMinTreeDepth, GcBench.kMaxTreeDepth);
         }
     }
 }

--- a/e2etest/src/test/java/fk/prof/recorder/main/AllocBurner.java
+++ b/e2etest/src/test/java/fk/prof/recorder/main/AllocBurner.java
@@ -6,7 +6,7 @@ package fk.prof.recorder.main;
 public class AllocBurner {
     public static void main(String[] args) {
         for (int i = 0; i < 10; i++) {
-            GcBench.runBenchmark(120, 60, GcBench.kArraySize, GcBench.kMinTreeDepth, GcBench.kMaxTreeDepth);
+            GcBench.runBenchmark(120, 100, GcBench.kArraySize, GcBench.kMinTreeDepth, GcBench.kMaxTreeDepth);
         }
     }
 }

--- a/recorder/.gitignore
+++ b/recorder/.gitignore
@@ -1,2 +1,3 @@
 libbagent.a
 libtestbase.a
+*.tmp

--- a/recorder/CMakeLists.txt
+++ b/recorder/CMakeLists.txt
@@ -179,6 +179,8 @@ set(TEST_FILES
     ${SRC_TEST}/test_syslog_tsdb_metric_formatter.cc
     ${SRC_TEST}/test_unique_readsafe_ptr.cc
     ${SRC_TEST}/test_site_resolver.cc
+    ${SRC_TEST}/test_backtracer.cc
+    ${SRC_TEST}/mapping_helper.cc
     ${SRC_TEST}/test.cc)
 
 set(TEST_UTIL_FILES

--- a/recorder/CMakeLists.txt
+++ b/recorder/CMakeLists.txt
@@ -202,7 +202,7 @@ set(GLOBAL_WARNINGS "${GLOBAL_WARNINGS} -Wno-sign-compare -Wno-strict-overflow -
 set(GLOBAL_WARNINGS "${GLOBAL_WARNINGS} -Wnon-virtual-dtor -Woverloaded-virtual")
 
 set(GLOBAL_COPTS "-fdiagnostics-show-option -fno-omit-frame-pointer -fno-strict-aliasing -DHAS_VALGRIND=${HAS_VALGRIND_H}")
-set(GLOBAL_COPTS "${GLOBAL_COPTS} -funsigned-char -fno-asynchronous-unwind-tables -msse2 -g -D__STDC_FORMAT_MACROS -O2 -fPIC")
+set(GLOBAL_COPTS "${GLOBAL_COPTS} -funsigned-char -fno-asynchronous-unwind-tables -msse2 -g -D__STDC_FORMAT_MACROS -fPIC")
 
 # Platform Specific
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -227,8 +227,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(GLOBAL_WARNINGS, "${GLOBAL_WARNINGS} -Wno-unknown-pragmas -Wno-builtin-macro-redefined -Wl,-fatal_warnings")
 endif()
 
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO  "-g3 -ggdb")
-set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O0") # -fsanitize=address when needed
+set(CMAKE_CXX_FLAGS_RELWITHDEBUGINFO  "-O2 -g3 -ggdb")
+set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g3 -ggdb") # -fsanitize=address when needed
 SET(VERBOSE_LOGS "n" CACHE STRING "'Enable Verbose Logging' flag, turns on compile-time controlled debug and trace logs, defaults to 'n'")
 if (${VERBOSE_LOGS} MATCHES "y")
   set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -DSPDLOG_TRACE_ON -DSPDLOG_DEBUG_ON")

--- a/recorder/src/idl/recorder.proto
+++ b/recorder/src/idl/recorder.proto
@@ -156,6 +156,7 @@ message CpuSampleWork {
   required uint32 frequency = 1;
   required uint32 max_frames = 2;
   optional uint32 serialization_flush_threshold = 3 [default = 100];
+  optional bool capture_error_bt = 4 [default = true];
 }
 
 message ThreadSampleWork {

--- a/recorder/src/main/cpp/circular_queue.cc
+++ b/recorder/src/main/cpp/circular_queue.cc
@@ -97,7 +97,7 @@ bool CircularQueue::pop() {
         usleep(1);
     }
 
-    listener_.record(buffer[current_output].trace, buffer[current_output].info, buffer[current_output].ctx_len, &buffer[current_output].ctx, buffer[current_output].default_ctx);
+    listener_.record(buffer[current_output].trace, buffer[current_output].info, buffer[current_output].ctx_len, &buffer[current_output].ctx, buffer[current_output].default_ctx, buffer[current_output].unreadable_bt);
     
     // ensure that the record is ready to be written to
     buffer[current_output].is_committed.store(UNCOMMITTED, std::memory_order_release);

--- a/recorder/src/main/cpp/circular_queue.hh
+++ b/recorder/src/main/cpp/circular_queue.hh
@@ -36,6 +36,7 @@ struct TraceHolder {
     PerfCtx::ThreadTracker::EffectiveCtx ctx;
     std::uint8_t ctx_len;
     bool default_ctx;
+    bool unreadable_bt;
 };
 
 class CircularQueue {
@@ -49,7 +50,7 @@ public:
     // Yuck! I know...
     bool push(const JVMPI_CallTrace &item, const BacktraceError error, bool default_ctx, ThreadBucket *info = nullptr);
 
-    bool push(const NativeFrame* item, const std::uint32_t num_frames, const BacktraceError error, bool default_ctx, ThreadBucket *info = nullptr);
+    bool push(const NativeFrame* item, const std::uint32_t num_frames, const BacktraceError error, bool default_ctx, bool unreadable_bt, ThreadBucket *info = nullptr);
 
     bool pop();
 
@@ -67,11 +68,11 @@ private:
 
     bool acquire_write_slot(size_t& slot);
 
-    void update_trace_info(StackFrame* fb, const BacktraceType type, const size_t slot, const std::uint32_t num_frames, ThreadBucket* info, const BacktraceError error, bool default_ctx);
+    void update_trace_info(StackFrame* fb, const BacktraceType type, const size_t slot, const std::uint32_t num_frames, ThreadBucket* info, const BacktraceError error, bool default_ctx, bool unreadable_bt);
 
     void write(const JVMPI_CallTrace& item, const size_t slot, ThreadBucket* info, const BacktraceError error, bool default_ctx);
 
-    void write(const NativeFrame* trace, const std::uint32_t num_frames, const size_t slot, ThreadBucket* info, const BacktraceError error, bool default_ctx);
+    void write(const NativeFrame* trace, const std::uint32_t num_frames, const size_t slot, ThreadBucket* info, const BacktraceError error, bool default_ctx, bool unreadable_bt);
 
     void mark_committed(const size_t slot);
 };

--- a/recorder/src/main/cpp/circular_queue.hh
+++ b/recorder/src/main/cpp/circular_queue.hh
@@ -21,7 +21,7 @@ const size_t Capacity = Size + 1;
 
 class QueueListener {
 public:
-    virtual void record(const Backtrace& item, ThreadBucket* info = nullptr, std::uint8_t ctx_len = 0, PerfCtx::ThreadTracker::EffectiveCtx* ctx = nullptr, bool default_ctx = false) = 0;
+    virtual void record(const Backtrace& item, ThreadBucket* info = nullptr, std::uint8_t ctx_len = 0, PerfCtx::ThreadTracker::EffectiveCtx* ctx = nullptr, bool default_ctx = false, bool unreadable_bt = false) = 0;
 
     virtual ~QueueListener() { }
 };

--- a/recorder/src/main/cpp/globals.hh
+++ b/recorder/src/main/cpp/globals.hh
@@ -42,10 +42,12 @@ namespace Time {
 extern LoggerP logger;//TODO: stick me in GlobalCtx???
 
 class Profiler;
+class Backtracer;
 
 namespace GlobalCtx {
     typedef struct {
         UniqueReadsafePtr<Profiler> cpu_profiler;
+        UniqueReadsafePtr<Backtracer> backtracer;
     } Rec;
 
     extern GlobalCtx::Rec recording;

--- a/recorder/src/main/cpp/mapping_parser.cc
+++ b/recorder/src/main/cpp/mapping_parser.cc
@@ -44,3 +44,8 @@ bool MRegion::Parser::feed(std::istream& input) {
     }
     return input.eof();
 }
+
+std::string MRegion::file() {
+    auto pid = getpid();
+    return "/proc/" + std::to_string(pid) + "/maps";
+}

--- a/recorder/src/main/cpp/mapping_parser.hh
+++ b/recorder/src/main/cpp/mapping_parser.hh
@@ -75,6 +75,8 @@ namespace MRegion {
 
         bool feed(std::istream& input);
     };
+
+    std::string file();
 }
 
 #endif

--- a/recorder/src/main/cpp/profile_writer.cc
+++ b/recorder/src/main/cpp/profile_writer.cc
@@ -112,7 +112,7 @@ ProfileSerializingWriter::CtxId ProfileSerializingWriter::report_ctx(PerfCtx::Tr
     }
 }
 
-void ProfileSerializingWriter::record(const Backtrace &trace, ThreadBucket *info, std::uint8_t ctx_len, PerfCtx::ThreadTracker::EffectiveCtx* ctx, bool default_ctx) {
+void ProfileSerializingWriter::record(const Backtrace &trace, ThreadBucket *info, std::uint8_t ctx_len, PerfCtx::ThreadTracker::EffectiveCtx* ctx, bool default_ctx, bool unreadable_bt) {
     if (cpu_samples_flush_ctr >= sft.cpu_samples) flush();
     cpu_samples_flush_ctr++;
     
@@ -153,7 +153,7 @@ void ProfileSerializingWriter::record(const Backtrace &trace, ThreadBucket *info
         ss->add_trace_id(known_ctx);
     }
 
-    auto snipped = trace.num_frames > trunc_thresholds.cpu_samples_max_stack_sz;
+    auto snipped = unreadable_bt || (trace.num_frames > trunc_thresholds.cpu_samples_max_stack_sz);
     if (snipped) s_c_frame_snipped.inc();
     ss->set_snipped(snipped);
 

--- a/recorder/src/main/cpp/profile_writer.hh
+++ b/recorder/src/main/cpp/profile_writer.hh
@@ -133,7 +133,7 @@ public:
 
     ~ProfileSerializingWriter();
 
-    virtual void record(const Backtrace &trace, ThreadBucket *info = nullptr, std::uint8_t ctx_len = 0, PerfCtx::ThreadTracker::EffectiveCtx* ctx = nullptr, bool default_ctx = false);
+    virtual void record(const Backtrace &trace, ThreadBucket *info = nullptr, std::uint8_t ctx_len = 0, PerfCtx::ThreadTracker::EffectiveCtx* ctx = nullptr, bool default_ctx = false, bool unreadable_bt = false);
 
     virtual MthId recordNewMethod(const jmethodID method_id, const char *file_name, const char *class_name, const char *method_name, const char *method_signature);
 

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -68,7 +68,11 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
 
     STATIC_ARRAY(native_trace, NativeFrame, capture_stack_depth(), MAX_FRAMES_TO_CAPTURE);
 
-    auto bt_len = Stacktraces::fill_backtrace(native_trace, capture_stack_depth());
+    ReadsafePtr<Backtracer> b_tracer(GlobalCtx::recording.backtracer);
+    std::uint32_t bt_len = 0;
+    if (b_tracer.available()) {
+        bt_len = b_tracer->fill_in(native_trace, capture_stack_depth());
+    }
     buffer->push(native_trace, bt_len, err, default_ctx, thread_info);
 }
 

--- a/recorder/src/main/cpp/profiler.cc
+++ b/recorder/src/main/cpp/profiler.cc
@@ -70,10 +70,11 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
 
     ReadsafePtr<Backtracer> b_tracer(GlobalCtx::recording.backtracer);
     std::uint32_t bt_len = 0;
+    bool bt_unreadable = false;
     if (b_tracer.available()) {
-        bt_len = b_tracer->fill_in(native_trace, capture_stack_depth());
+        bt_len = b_tracer->fill_in(native_trace, capture_stack_depth(), bt_unreadable);
     }
-    buffer->push(native_trace, bt_len, err, default_ctx, thread_info);
+    buffer->push(native_trace, bt_len, err, default_ctx, bt_unreadable, thread_info);
 }
 
 bool Profiler::start(JNIEnv *jniEnv) {

--- a/recorder/src/main/cpp/site_resolver.cc
+++ b/recorder/src/main/cpp/site_resolver.cc
@@ -397,8 +397,8 @@ void SiteResolver::SymInfo::update_mapped_ranges(std::function<void()> post_pars
 
             return true;
         });
-    auto pid = getpid();
-    std::fstream f_maps("/proc/" + std::to_string(pid) + "/maps", std::ios::in);
+    auto maps_file = MRegion::file();
+    std::fstream f_maps(maps_file, std::ios::in);
     parser.feed(f_maps);
     post_parse_cb();
     char executable_path[PATH_MAX];

--- a/recorder/src/main/cpp/stacktraces.cc
+++ b/recorder/src/main/cpp/stacktraces.cc
@@ -1,20 +1,48 @@
 #include "stacktraces.hh"
+#include "mapping_parser.hh"
+#include <fstream>
 
-std::uint32_t Stacktraces::fill_backtrace(NativeFrame* buff, std::uint32_t capacity) {//TODO: write me 3 tests { (capacity > stack), (stack > capacity) and (stack == capacity) }
+Backtracer::Backtracer(const std::string& path, bool _enabled) : enabled(_enabled) {
+    MRegion::Parser parser([&](const MRegion::Event& e) {
+            if (e.perms.find('w') == std::string::npos) return true;
+
+            std::size_t pos;
+            NativeFrame start = std::stoull(e.range.start, &pos, 16);
+            assert(pos == e.range.start.length());
+            NativeFrame end = std::stoull(e.range.end, &pos, 16);
+            assert(pos == e.range.end.length());
+            
+            mapped.emplace_back(start, end);
+
+            return true;
+        });
+    std::fstream f_maps(path, std::ios::in);
+    parser.feed(f_maps);
+}
+
+static bool compare(const Backtracer::Entry& one, const Backtracer::Entry& other) {
+    return one.second < other.second;
+}
+
+std::uint32_t Backtracer::fill_in(NativeFrame* buff, std::uint32_t capacity) {//TODO: write me 3 tests { (capacity > stack), (stack > capacity) and (stack == capacity) }
+    if (! enabled) return 0;
     std::uint64_t rbp, rpc;
     asm("movq %%rbp, %%rax;"
         "movq %%rax, %0;"
-        "lea (%%rip), %%rax;"
-        "movq %%rax, %1;"
-        : "=r"(rbp), "=r"(rpc)
+        : "=r"(rbp)
         :
         : "rax");
 
     //not adding current PC, because we are anyway not interested in showing ourselves on the backtrace
     std::uint32_t i = 0;
+    Entry key;
+    auto start = std::begin(mapped);
+    auto end = std::end(mapped);
     while ((capacity - i) > 0) {
+        key.second = rbp;
+        auto it = std::lower_bound(start, end, key, compare);
+        if (it == end || it->first > rbp || it->second < (rbp + 16)) break;
         rpc = *reinterpret_cast<std::uint64_t*>(rbp + 8);
-        //if (rpc == 0) break;
         buff[i] = rpc;
         rbp = *reinterpret_cast<std::uint64_t*>(rbp);
         if (rbp == 0) break;

--- a/recorder/src/main/cpp/stacktraces.hh
+++ b/recorder/src/main/cpp/stacktraces.hh
@@ -139,8 +139,18 @@ private:
     DISALLOW_IMPLICIT_CONSTRUCTORS(Asgct);
 };
 
-namespace Stacktraces {
-    std::uint32_t fill_backtrace(NativeFrame* buff, std::uint32_t capacity);
-}
+class Backtracer {
+public:
+    typedef std::pair<NativeFrame, NativeFrame> Entry;
+
+    Backtracer(const std::string& path, bool enabled = true);
+    
+    std::uint32_t fill_in(NativeFrame* buff, std::uint32_t capacity);
+    
+private:
+    std::vector<Entry> mapped;//TODO: rename this NativeFrame to NativeAddr (because it really isn't a frame, its an address)
+
+    bool enabled;
+};
 
 #endif // STACKTRACES_H

--- a/recorder/src/main/cpp/stacktraces.hh
+++ b/recorder/src/main/cpp/stacktraces.hh
@@ -145,7 +145,7 @@ public:
 
     Backtracer(const std::string& path, bool enabled = true);
     
-    std::uint32_t fill_in(NativeFrame* buff, std::uint32_t capacity);
+    std::uint32_t fill_in(NativeFrame* buff, std::uint32_t capacity, bool& bt_unreadable);
     
 private:
     std::vector<Entry> mapped;//TODO: rename this NativeFrame to NativeAddr (because it really isn't a frame, its an address)

--- a/recorder/src/test/cpp/fixtures.hh
+++ b/recorder/src/test/cpp/fixtures.hh
@@ -8,7 +8,7 @@ class ItemHolder : public QueueListener {
 public:
   explicit ItemHolder() {}
 
-    virtual void record(const Backtrace &trace, ThreadBucket *info, std::uint8_t ctx_len, PerfCtx::ThreadTracker::EffectiveCtx* ctx, bool default_ctx) {
+    virtual void record(const Backtrace &trace, ThreadBucket *info, std::uint8_t ctx_len, PerfCtx::ThreadTracker::EffectiveCtx* ctx, bool default_ctx, bool unreadable_bt) {
         CHECK_EQUAL(2, trace.num_frames);
         CHECK_EQUAL(BacktraceType::Java, trace.type);
 

--- a/recorder/src/test/cpp/mapping_helper.cc
+++ b/recorder/src/test/cpp/mapping_helper.cc
@@ -1,0 +1,156 @@
+#include "mapping_helper.hh"
+#include "test.hh"
+#include "test_helpers.hh"
+#include <fstream>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+void find_mappable_ranges_between(const CurrMappings& curr_mappings, SiteResolver::Addr desired_start, SiteResolver::Addr desired_end, MappableRanges& mappable) {
+    mappable[desired_start] = desired_end;
+    for (auto& cm : curr_mappings) {
+        //std::cout << "C: [" << cm.first << ", " << cm.second  << "]\n";
+        auto it = mappable.lower_bound(cm.first);
+        if (it == std::begin(mappable)) {
+            if (mappable.lower_bound(cm.second) == it) continue;
+        }
+        it--;
+        while (it != std::end(mappable) &&
+               it->first < desired_end) {
+            auto start = it->first;
+            auto end = it->second;
+            //std::cout << "x [" << start << ", " << end << "]\n";
+            if (start <= cm.second &&
+                cm.first <= end) { //overlap
+                it = mappable.erase(it);
+                //std::cout << "- [" << start << ", " << end << "]\n";
+                if (start < cm.first) {
+                    mappable[start] = cm.first - 1;
+                    //std::cout << "+ [" << start << ", " << cm.first - 1 << "]\n";
+                }
+                if (end > cm.second) {
+                    mappable[cm.second + 1] = end;
+                    //std::cout << "+ [" << cm.second + 1 << ", " << end << "]\n";
+                }
+            } else {
+                it++;
+            }
+        }
+    }
+}
+
+TEST(MappingHelper__mappable_range_finder) {
+    CurrMappings cms;
+    cms.emplace_back(100, 200);
+    cms.emplace_back(300, 400);
+    cms.emplace_back(500, 600);
+    MappableRanges mappable;
+    find_mappable_ranges_between(cms, 150, 550, mappable);
+
+    CHECK_EQUAL(2, mappable.size());
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+
+    mappable.clear();
+    find_mappable_ranges_between(cms, 100, 550, mappable);
+
+    CHECK_EQUAL(2, mappable.size());
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+
+    mappable.clear();
+    find_mappable_ranges_between(cms, 150, 500, mappable);
+
+    CHECK_EQUAL(2, mappable.size());
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+
+    mappable.clear();
+    find_mappable_ranges_between(cms, 150, 600, mappable);
+
+    CHECK_EQUAL(2, mappable.size());
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+
+    mappable.clear();
+    find_mappable_ranges_between(cms, 100, 600, mappable);
+
+    CHECK_EQUAL(2, mappable.size());
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+
+    mappable.clear();
+    find_mappable_ranges_between(cms, 99, 601, mappable);
+
+    CHECK_EQUAL(4, mappable.size());
+    CHECK_EQUAL(99, mappable[99]);
+    CHECK_EQUAL(299, mappable[201]);
+    CHECK_EQUAL(499, mappable[401]);
+    CHECK_EQUAL(601, mappable[601]);
+
+    mappable.clear();
+    cms.emplace_back(201, 299);
+    find_mappable_ranges_between(cms, 150, 550, mappable);
+
+    CHECK_EQUAL(1, mappable.size());
+    CHECK_EQUAL(499, mappable[401]);
+}
+
+void iterate_mapping(std::function<void(SiteResolver::Addr start, SiteResolver::Addr end, const MRegion::Event& e)> cb) {
+    MRegion::Parser parser([&](const MRegion::Event& e) {
+            std::size_t pos;
+            std::uint64_t start = std::stoull(e.range.start, &pos, 16);
+            assert(pos == e.range.start.length());
+            std::uint64_t end = std::stoull(e.range.end, &pos, 16);
+            assert(pos == e.range.end.length());
+
+            cb(start, end, e);
+
+            return true;
+        });
+    auto pid = getpid();
+    std::fstream f_maps("/proc/" + std::to_string(pid) + "/maps", std::ios::in);
+    parser.feed(f_maps);
+}
+
+void map_one_anon_executable_page_between_executable_and_testlib(void **mmap_region, long& pg_sz, std::string path) {
+    auto dir = path.substr(0, path.rfind("/"));
+    std::pair<SiteResolver::Addr, SiteResolver::Addr> test_bin, test_util_lib;
+    CurrMappings curr_mappings;
+    iterate_mapping([&](SiteResolver::Addr start, SiteResolver::Addr end, const MRegion::Event& e) {
+            curr_mappings.push_back({start, end});
+
+            if (e.perms.find('x') != std::string::npos) {
+                if (e.path == path) test_bin = {start, end};
+                if (e.path == my_test_helper_lib()) test_util_lib = {start, end};
+            }
+        });
+
+    SiteResolver::Addr desired_anon_exec_map_lowerb, desired_anon_exec_map_upperb;
+
+    if (test_bin.first < test_util_lib.first) {
+        desired_anon_exec_map_lowerb = test_bin.second + 1;
+        desired_anon_exec_map_upperb = test_util_lib.first - 1;
+    } else {
+        desired_anon_exec_map_lowerb = test_util_lib.second + 1;
+        desired_anon_exec_map_upperb = test_bin.first - 1;
+    }
+
+    MappableRanges mappable;
+    find_mappable_ranges_between(curr_mappings, desired_anon_exec_map_lowerb, desired_anon_exec_map_upperb, mappable);
+
+    pg_sz = sysconf(_SC_PAGESIZE);
+
+    CHECK(mappable.size() > 0); //otherwise this test can't proceed (unlucky shot, please try again)
+    auto buff_mapped = false;
+    *mmap_region = nullptr;
+    for (const auto& m : mappable) {
+        if ((m.second - m.first) >= (3 * pg_sz)) {
+            *mmap_region = reinterpret_cast<void*>(m.first - (m.first % pg_sz) + pg_sz);
+            *mmap_region = mmap(*mmap_region, pg_sz, PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0);
+            buff_mapped = (*mmap_region != MAP_FAILED);
+            break;
+        }
+    }
+    CHECK(buff_mapped); //otherwise this test can't proceed (unlucky shot, please try again)
+}

--- a/recorder/src/test/cpp/mapping_helper.hh
+++ b/recorder/src/test/cpp/mapping_helper.hh
@@ -11,3 +11,5 @@ void find_mappable_ranges_between(const CurrMappings& curr_mappings, SiteResolve
 void iterate_mapping(std::function<void(SiteResolver::Addr start, SiteResolver::Addr end, const MRegion::Event& e)> cb);
 
 void map_one_anon_executable_page_between_executable_and_testlib(void **mmap_region, long& pg_sz, std::string path);
+
+void find_atleast_16_bytes_wide_unmapped_range(std::uint64_t& start, std::uint64_t& end);

--- a/recorder/src/test/cpp/mapping_helper.hh
+++ b/recorder/src/test/cpp/mapping_helper.hh
@@ -1,0 +1,13 @@
+#include <vector>
+#include <map>
+#include <site_resolver.hh>
+#include <mapping_parser.hh>
+
+typedef std::vector<std::pair<SiteResolver::Addr, SiteResolver::Addr>> CurrMappings;
+typedef std::map<SiteResolver::Addr, SiteResolver::Addr> MappableRanges;
+
+void find_mappable_ranges_between(const CurrMappings& curr_mappings, SiteResolver::Addr desired_start, SiteResolver::Addr desired_end, MappableRanges& mappable);
+
+void iterate_mapping(std::function<void(SiteResolver::Addr start, SiteResolver::Addr end, const MRegion::Event& e)> cb);
+
+void map_one_anon_executable_page_between_executable_and_testlib(void **mmap_region, long& pg_sz, std::string path);

--- a/recorder/src/test/cpp/test_backtracer.cc
+++ b/recorder/src/test/cpp/test_backtracer.cc
@@ -1,0 +1,37 @@
+#include <thread>
+#include <vector>
+#include <iostream>
+#include <cstdint>
+#include <chrono>
+#include "fixtures.hh"
+#include "test.hh"
+#include <mapping_parser.hh>
+#include <site_resolver.hh>
+#include "test_helpers.hh"
+#include <set>
+#include <linux/limits.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <sys/mman.h>
+
+#ifdef HAS_VALGRIND
+#include <valgrind/valgrind.h>
+#endif
+
+#include "mapping_helper.hh"
+
+TEST(Backtracer__should_not_fill_anything_when_native_backtracing_is_disabled) {
+    TestEnv _;
+    auto maps_file = MRegion::file();
+    Backtracer btracer(maps_file, false);
+    
+    const std::uint32_t buff_sz = 100;
+    NativeFrame buff[buff_sz];
+    buff[0] = 1;
+    CHECK_EQUAL(0, btracer.fill_in(buff, buff_sz));
+    CHECK_EQUAL(1, buff[0]); //its unchanged
+}

--- a/recorder/src/test/cpp/test_backtracer.cc
+++ b/recorder/src/test/cpp/test_backtracer.cc
@@ -32,6 +32,8 @@ TEST(Backtracer__should_not_fill_anything_when_native_backtracing_is_disabled) {
     const std::uint32_t buff_sz = 100;
     NativeFrame buff[buff_sz];
     buff[0] = 1;
-    CHECK_EQUAL(0, btracer.fill_in(buff, buff_sz));
+    bool bt_unreadable = true;
+    CHECK_EQUAL(0, btracer.fill_in(buff, buff_sz, bt_unreadable));
+    CHECK_EQUAL(false, bt_unreadable);
     CHECK_EQUAL(1, buff[0]); //its unchanged
 }

--- a/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
+++ b/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
@@ -97,7 +97,7 @@ jmethodID mid(std::uint64_t id) {
     {                                                                   \
         CHECK_EQUAL(mthd_id, mthd_info.method_id());                    \
         auto mthd_file = mthd_info.file_name();                         \
-        CHECK_EQUAL(kls_file, (mthd_file[0] == "/") ? abs_path(mthd_file) : mthd_file); \
+        CHECK_EQUAL(kls_file, (mthd_file[0] == '/') ? abs_path(mthd_file) : mthd_file); \
         CHECK_EQUAL(kls_fqdn, mthd_info.class_fqdn());                  \
         CHECK_EQUAL(fn_name, mthd_info.method_name());                  \
         CHECK_EQUAL(fn_sig, mthd_info.signature());                     \

--- a/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
+++ b/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
@@ -199,8 +199,9 @@ std::unique_ptr<Backtracer> b_tracer{nullptr};
 
 void bt_pusher() {
     STATIC_ARRAY(frames, NativeFrame, native_bt_max_depth, native_bt_max_depth);
-    auto len = b_tracer->fill_in(frames, native_bt_max_depth);
-    bt_q->push(frames, len, bt_err, mark_default_ctx, bt_tinfo);
+    bool bt_unreadable;
+    auto len = b_tracer->fill_in(frames, native_bt_max_depth, bt_unreadable);
+    bt_q->push(frames, len, bt_err, mark_default_ctx, bt_unreadable, bt_tinfo);
 }
 
 void push_native_backtrace(ThreadBucket* t, BacktraceError err, CircularQueue& q, bool default_ctx = false, int capture_bt_at = 4) {

--- a/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
+++ b/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
@@ -17,6 +17,7 @@
 #include "test_helpers.hh"
 #include <algorithm>
 #include <mapping_parser.hh>
+#include "mapping_helper.hh"
 
 namespace std {
     template <> struct hash<std::tuple<std::int64_t, jint>> {
@@ -222,6 +223,14 @@ void push_native_backtrace(ThreadBucket* t, BacktraceError err, CircularQueue& q
     bt_tinfo = nullptr;
 }
 
+void corrupted_frame_pointer_backtrace(ThreadBucket* t, BacktraceError err, CircularQueue& q, std::uint64_t unmapped_addr) {
+    std::size_t capacity = 10;
+    STATIC_ARRAY(frames, NativeFrame, capacity, capacity);
+    bool bt_unreadable;
+    auto len = bt_test_quux(*b_tracer, frames, capacity, bt_unreadable, unmapped_addr);
+    q.push(frames, len, err, false, bt_unreadable, t);
+}
+
 TEST(ProfileSerializer__should_write_cpu_samples_native_and_java) {
     TestEnv _;
     auto map_file = MRegion::file();
@@ -418,6 +427,106 @@ TEST(ProfileSerializer__should_write_cpu_samples_native_and_java) {
     ASSERT_NATIVE_STACK_SAMPLE_IS(cse.stack_sample(5), 0, NO_THD, sn2, sn2_ctxs, false);
 }
 
+TEST(ProfileSerializer__should_handle_frame_pointer_omitted_code_gracefully) {
+    TestEnv _;
+    auto map_file = MRegion::file();
+    b_tracer.reset(new Backtracer(map_file));
+    BlockingRingBuffer buff(1024 * 1024);
+    std::shared_ptr<RawWriter> raw_w_ptr(new AccumulatingRawWriter(buff));
+    Buff pw_buff;
+    ProfileWriter pw(raw_w_ptr, pw_buff);
+
+    method_lookup_stub.clear();
+    line_no_lookup_stub.clear();
+    
+    std::int64_t capture_bt = 1, bt_foo = 2, bt_bar = 3, bt_baz = 4;
+
+    PerfCtx::Registry reg;
+    auto to_parent_semantic = static_cast<std::uint8_t>(PerfCtx::MergeSemantic::to_parent);
+    auto ctx_foo = reg.find_or_bind("foo", 20, to_parent_semantic);
+    
+    ProbPct ppct;
+    prob_pct = &ppct;
+    ctx_reg = &reg;
+
+    jvmtiEnv* ti = nullptr;
+
+    SerializationFlushThresholds sft;
+    TruncationThresholds tts(7);
+    ProfileSerializingWriter ps(ti, pw, test_mthd_info_resolver, test_line_no_resolver, reg, sft, tts, 15);
+
+    CircularQueue q(ps, 10);
+    
+    std::uint64_t start, end;
+    find_atleast_16_bytes_wide_unmapped_range(start, end);
+
+    ThreadBucket t25(25, "Thread No. 25", 5, true);
+
+    t25.ctx_tracker.enter(ctx_foo);
+    corrupted_frame_pointer_backtrace(ThreadBucket::acq_bucket(&t25), BacktraceError::Fkp_no_error, q, start);
+    t25.ctx_tracker.exit(ctx_foo);
+
+    CHECK(q.pop());
+    CHECK(! q.pop());//because only 1 sample was pushed
+
+    ps.flush();
+
+    std::shared_ptr<std::uint8_t> tmp_buff(new std::uint8_t[1024 * 1024], std::default_delete<std::uint8_t[]>());
+    auto bytes_sz = buff.read(tmp_buff.get(), 0, 1024 * 1024, false);
+    CHECK(bytes_sz > 0);
+
+    google::protobuf::io::CodedInputStream cis(tmp_buff.get(), bytes_sz);
+
+    std::uint32_t len;
+    CHECK(cis.ReadVarint32(&len));
+
+    auto lim = cis.PushLimit(len);
+
+    recording::Wse wse;
+    CHECK(wse.ParseFromCodedStream(&cis));
+
+    cis.PopLimit(lim);
+
+    auto pos = cis.CurrentPosition();
+
+    std::uint32_t csum;
+    CHECK(cis.ReadVarint32(&csum));
+
+    Checksum c_calc;
+    auto computed_csum = c_calc.chksum(tmp_buff.get(), pos);
+
+    CHECK_EQUAL(computed_csum, csum);
+
+    CHECK_EQUAL(recording::WorkType::cpu_sample_work, wse.w_type());
+    auto idx_data = wse.indexed_data();
+    CHECK_EQUAL(0, idx_data.monitor_info_size());
+    
+    CHECK_EQUAL(1, idx_data.thread_info_size());
+    ASSERT_THREAD_INFO_IS(idx_data.thread_info(0), 3, "Thread No. 25", 5, true, 25);
+
+    CHECK_EQUAL(5, idx_data.method_info_size());
+    ASSERT_METHOD_INFO_IS(idx_data.method_info(0), 0, "?", "?", "?", "?", Java_Sym);
+    auto test_executable = my_executable();
+    auto test_helper_lib = my_test_helper_lib();
+    ASSERT_METHOD_INFO_IS(idx_data.method_info(1), capture_bt, test_helper_lib, "", "capture_bt(Backtracer&, unsigned long*, unsigned long, bool&)", "", Native_Sym);
+    ASSERT_METHOD_INFO_IS(idx_data.method_info(2), bt_foo, test_helper_lib, "", "bt_test_foo(Backtracer&, unsigned long*, unsigned long, bool&)", "", Native_Sym);
+    ASSERT_METHOD_INFO_IS(idx_data.method_info(3), bt_bar, test_helper_lib, "", "bt_test_bar(Backtracer&, unsigned long*, unsigned long, bool&, unsigned long)", "", Native_Sym);
+    ASSERT_METHOD_INFO_IS(idx_data.method_info(4), bt_baz, test_helper_lib, "", "bt_test_baz(Backtracer&, unsigned long*, unsigned long, bool&, unsigned long)", "", Native_Sym);
+    //observe there is no bt_quux here
+
+    CHECK_EQUAL(3, idx_data.trace_ctx_size());
+    ASSERT_TRACE_CTX_INFO_IS(idx_data.trace_ctx(0), 0, DEFAULT_CTX_NAME, 15, 0, false);
+    ASSERT_TRACE_CTX_INFO_IS(idx_data.trace_ctx(1), 1, UNKNOWN_CTX_NAME, 0, 0, true);
+    ASSERT_TRACE_CTX_INFO_IS(idx_data.trace_ctx(2), 5, "foo", 20, 0, false);
+
+    auto cse = wse.cpu_sample_entry();
+
+    CHECK_EQUAL(1, cse.stack_sample_size());
+    auto sn1 = {capture_bt, bt_foo, bt_bar, bt_baz};
+    auto sn1_ctxs = {5};
+    ASSERT_NATIVE_STACK_SAMPLE_IS(cse.stack_sample(0), 0, 3, sn1, sn1_ctxs, true);
+}
+
 TEST(ProfileSerializer__should_write_cpu_samples__with_scoped_ctx) {
     TestEnv _;
     auto map_file = MRegion::file();
@@ -543,7 +652,6 @@ TEST(ProfileSerializer__should_write_cpu_samples__with_scoped_ctx) {
     auto s2_ctxs = {6};
     ASSERT_STACK_SAMPLE_IS(cse.stack_sample(2), 0, 3, s2, s2_ctxs, false);
 }
-
 
 TEST(ProfileSerializer__should_auto_flush__at_buffering_threshold) {
     TestEnv _;

--- a/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
+++ b/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
@@ -96,7 +96,8 @@ jmethodID mid(std::uint64_t id) {
 #define ASSERT_METHOD_INFO_IS(mthd_info, mthd_id, kls_file, kls_fqdn, fn_name, fn_sig, code_cls) \
     {                                                                   \
         CHECK_EQUAL(mthd_id, mthd_info.method_id());                    \
-        CHECK_EQUAL(kls_file, mthd_info.file_name());                   \
+        auto mthd_file = mthd_info.file_name();                         \
+        CHECK_EQUAL(kls_file, (mthd_file[0] == "/") ? abs_path(mthd_file) : mthd_file); \
         CHECK_EQUAL(kls_fqdn, mthd_info.class_fqdn());                  \
         CHECK_EQUAL(fn_name, mthd_info.method_name());                  \
         CHECK_EQUAL(fn_sig, mthd_info.signature());                     \

--- a/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
+++ b/recorder/src/test/cpp/test_cpu_sampling_profile_serialization.cc
@@ -159,7 +159,8 @@ std::tuple<F_mid, F_bci, F_line> fr(F_mid mid, F_bci bci, F_line line) {
     }
 
 //[#]  calling convention will take a few instructions
-//[##] just a guess, these functions are fairly small, so won't have more than 100 bytes worth of text
+//[##] just a guess, these functions are fairly small, so won't have more than 300 bytes
+//     (it was 100 bytes, but then uniq-ptr and g++ changed things) worth of text
 #define ASSERT_NATIVE_STACK_SAMPLE_IS(ss, time_offset, thd_id, frames, ctx_ids, is_snipped) \
     {                                                                   \
         CHECK_EQUAL(time_offset, ss.start_offset_micros());             \
@@ -174,7 +175,7 @@ std::tuple<F_mid, F_bci, F_line> fr(F_mid mid, F_bci bci, F_line line) {
             auto f = ss.frame(i);                                       \
             CHECK_EQUAL((*it), f.method_id());                          \
             CHECK(f.bci() > 0); /* [#] */                               \
-            CHECK(f.bci() < 100); /* [##] */                            \
+            CHECK(f.bci() < 300); /* [##] */                            \
         }                                                               \
         CHECK_EQUAL(frames.size(), i);                                  \
         CHECK_EQUAL(ctx_ids.size(), ss.trace_id_size());                \

--- a/recorder/src/test/cpp/test_helpers.cc
+++ b/recorder/src/test/cpp/test_helpers.cc
@@ -99,6 +99,7 @@ static void dereference_symlink(std::stringstream& path) {
     auto curr_path = path.str();
     auto ret = readlink(curr_path.c_str(), dest, PATH_MAX);
     assert(ret > 0);
+    dest[ret] = '\0';
     path.str(dest);
     path.clear();
 }

--- a/recorder/src/test/cpp/test_helpers.cc
+++ b/recorder/src/test/cpp/test_helpers.cc
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sstream>
+#include <list>
 
 __attribute__ ((noinline)) void some_lambda_caller(std::function<void()> fn) {
     fn();
@@ -98,8 +99,8 @@ static void dereference_symlink(std::stringstream& path) {
     auto curr_path = path.str();
     auto ret = readlink(curr_path.c_str(), dest, PATH_MAX);
     assert(ret > 0);
+    path.str(dest);
     path.clear();
-    path << dest;
 }
 
 std::string abs_path(const std::string& path) {
@@ -113,6 +114,7 @@ std::string abs_path(const std::string& path) {
         if (is_symlink(curr_path.str())) {
             dereference_symlink(curr_path);
             fragment_path(curr_path.str(), frags);
+            curr_path.str("");
             curr_path.clear();
         }
     }

--- a/recorder/src/test/cpp/test_helpers.cc
+++ b/recorder/src/test/cpp/test_helpers.cc
@@ -56,10 +56,7 @@ __attribute__ ((noinline)) void fn_corge(int p, int q, int bt_capture_depth) {
 }
 
 std::string my_executable() {
-    char link_path[PATH_MAX];
-    auto path_len = readlink("/proc/self/exe", link_path, PATH_MAX);
-    link_path[path_len] = '\0';
-    return {link_path};
+    return readlink_path("/proc/self/exe");
 }
 
 std::string my_test_helper_lib() {
@@ -69,4 +66,15 @@ std::string my_test_helper_lib() {
     std::string dir_name_str {dir_name};
     dir_name_str += LIB_TEST_UTIL;
     return dir_name_str;
+}
+
+std::string readlink_path(const std::string& path) {
+    char link_path[PATH_MAX];
+    auto path_len = readlink(path.c_str(), link_path, PATH_MAX);
+    if (path_len < 0) {
+        assert(errno == EINVAL);
+        return path;
+    }
+    link_path[path_len] = '\0';
+    return {link_path};
 }

--- a/recorder/src/test/cpp/test_helpers.hh
+++ b/recorder/src/test/cpp/test_helpers.hh
@@ -28,4 +28,15 @@ std::string my_test_helper_lib();
 
 std::string abs_path(const std::string& path);
 
+__attribute__ ((noinline)) std::uint32_t capture_bt(Backtracer& b_tracer, NativeFrame* bt, std::size_t capacity, bool& bt_unreadable);
+
+__attribute__ ((noinline)) std::uint32_t bt_test_foo(Backtracer& b_tracer, NativeFrame* bt, std::size_t capacity, bool& bt_unreadable);
+
+__attribute__ ((noinline)) std::uint32_t bt_test_bar(Backtracer& b_tracer, NativeFrame* bt, std::size_t capacity, bool& bt_unreadable, std::uint64_t unmapped_address);
+
+__attribute__ ((noinline)) std::uint32_t bt_test_baz(Backtracer& b_tracer, NativeFrame* bt, std::size_t capacity, bool& bt_unreadable, std::uint64_t unmapped_address);
+
+__attribute__ ((noinline)) std::uint32_t bt_test_quux(Backtracer& b_tracer, NativeFrame* bt, std::size_t capacity, bool& bt_unreadable, std::uint64_t unmapped_address);
+
+
 #endif /* TEST_HELPERS_H */

--- a/recorder/src/test/cpp/test_helpers.hh
+++ b/recorder/src/test/cpp/test_helpers.hh
@@ -26,4 +26,6 @@ std::string my_executable();
 
 std::string my_test_helper_lib();
 
+std::string readlink_path(const std::string& path);
+
 #endif /* TEST_HELPERS_H */

--- a/recorder/src/test/cpp/test_helpers.hh
+++ b/recorder/src/test/cpp/test_helpers.hh
@@ -26,6 +26,6 @@ std::string my_executable();
 
 std::string my_test_helper_lib();
 
-std::string readlink_path(const std::string& path);
+std::string abs_path(const std::string& path);
 
 #endif /* TEST_HELPERS_H */

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -321,19 +321,19 @@ TEST(SiteResolver__should_handle_mapping_changes_between___mmap_parse___and___dl
                                                                         \
         s_info.site_for(bt[0] , file_name, fn_name, pc_offset);         \
         CHECK_EQUAL("capture_bt(Backtracer&, unsigned long*, unsigned long, bool&)", fn_name); \
-        CHECK_EQUAL(path, file_name);                                   \
+        CHECK_EQUAL(path, abs_path(file_name));                         \
                                                                         \
         s_info.site_for(bt[1] , file_name, fn_name, pc_offset);         \
         CHECK_EQUAL("bt_test_foo(Backtracer&, unsigned long*, unsigned long, bool&)", fn_name); \
-        CHECK_EQUAL(path, file_name);                                   \
+        CHECK_EQUAL(path, abs_path(file_name));                         \
                                                                         \
         s_info.site_for(bt[2] , file_name, fn_name, pc_offset);         \
         CHECK_EQUAL("bt_test_bar(Backtracer&, unsigned long*, unsigned long, bool&, unsigned long)", fn_name); \
-        CHECK_EQUAL(path, file_name);                                   \
+        CHECK_EQUAL(path, abs_path(file_name));                         \
                                                                         \
         s_info.site_for(bt[3] , file_name, fn_name, pc_offset);         \
         CHECK_EQUAL("bt_test_baz(Backtracer&, unsigned long*, unsigned long, bool&, unsigned long)", fn_name); \
-        CHECK_EQUAL(path, file_name);                                   \
+        CHECK_EQUAL(path, abs_path(file_name));                         \
     }
 //observe there is no bt_test_quux above, hence limited length.
 

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -215,7 +215,7 @@ TEST(SiteResolver__should_handle_mapping_changes_between___mmap_parse___and___dl
             map_target_1 << '0';
         }
     }
-    auto mt1_path = std::string(dir.get()) + "/" + mt1;
+    auto mt1_path = abs_path(std::string(dir.get()) + "/" + mt1);
 
     auto mt1_fd = open(mt1_path.c_str(), O_RDONLY);
     CHECK(fchmod(mt1_fd, S_IRUSR | S_IXUSR) == 0);

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -67,7 +67,7 @@ TEST(SiteResolver__should_resolve_backtrace) {
     auto it = fn_files.find("some_lambda_caller(std::function<void ()>)");
     CHECK(it != std::end(fn_files));//this symbol comes from a shared-lib (aim is to ensure it works well with relocatable symbols)
 
-    CHECK_EQUAL(readlink_path(it->second), my_test_helper_lib());
+    CHECK_EQUAL(my_test_helper_lib(), abs_path(it->second));
 }
 
 TEST(SiteResolver__should_call_out_unknown_mapping) {

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -72,8 +72,6 @@ TEST(SiteResolver__should_resolve_backtrace) {
     auto it = fn_files.find("some_lambda_caller(std::function<void ()>)");
     CHECK(it != std::end(fn_files));//this symbol comes from a shared-lib (aim is to ensure it works well with relocatable symbols)
 
-    auto dir = path.substr(0, path.rfind("/"));
-    CHECK_EQUAL(0, it->second.find(dir));
     CHECK_EQUAL(my_test_helper_lib(), it->second);
 }
 

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -25,7 +25,8 @@
 static std::unique_ptr<Backtracer> b_tracer {nullptr};
 
 __attribute__ ((noinline)) int foo(NativeFrame* buff, std::uint32_t sz) {
-    return b_tracer->fill_in(buff, sz);
+    bool bt_unreadable;
+    return b_tracer->fill_in(buff, sz, bt_unreadable);
 }
 
 __attribute__ ((noinline)) int caller_of_foo(NativeFrame* buff, std::uint32_t sz) {
@@ -321,8 +322,11 @@ static NativeFrame bt[BT_SZ];
 
 static std::uint64_t unmapped_address;
 
+static bool bt_unreadable;
+
 __attribute__ ((noinline)) static void capture_bt() {
-    bt_len = b_tracer->fill_in(bt, BT_SZ);
+    bt_unreadable = false;
+    bt_len = b_tracer->fill_in(bt, BT_SZ, bt_unreadable);
 }
 
 __attribute__ ((noinline)) static void bt_test_foo() {

--- a/recorder/src/test/cpp/test_site_resolver.cc
+++ b/recorder/src/test/cpp/test_site_resolver.cc
@@ -45,12 +45,7 @@ TEST(SiteResolver__should_resolve_backtrace) {
         });
     CHECK(bt_len > 4);
 
-    auto max_path_sz = 1024;
-    std::unique_ptr<char[]> link_path(new char[max_path_sz]);
-    auto path_len = readlink("/proc/self/exe", link_path.get(), max_path_sz);
-    CHECK((path_len > 0) && (path_len < max_path_sz));//ensure we read link correctly
-    link_path.get()[path_len] = '\0';
-    std::string path = link_path.get();
+    std::string path = my_executable();
 
     SiteResolver::SymInfo s_info;
     std::string fn_name;
@@ -72,7 +67,7 @@ TEST(SiteResolver__should_resolve_backtrace) {
     auto it = fn_files.find("some_lambda_caller(std::function<void ()>)");
     CHECK(it != std::end(fn_files));//this symbol comes from a shared-lib (aim is to ensure it works well with relocatable symbols)
 
-    CHECK_EQUAL(my_test_helper_lib(), it->second);
+    CHECK_EQUAL(readlink_path(it->second), my_test_helper_lib());
 }
 
 TEST(SiteResolver__should_call_out_unknown_mapping) {


### PR DESCRIPTION
The previous merge of this branch didn't account for frame-pointer omitted code.

This PR deals with that by reading up the mapping just before it we start profiling and not trying to dereference %rbp when we believe it is not mapped.

Of-course, this assumes a sane application that doesn't create and discard threads at drop of a hat. But of-course some applications will have such bad usage of threads(mature ones won't, though).

For bad applications like that, native-bt can be disabled using a policy flag.

For well behaved applications, if all code maintains frame-pointers, we are golden, we get all backtraces.

For well behaved application, with some frame-pointer-omitted code, we will follow backtrace as far as we think its making sense.

Eg. if suddenly we find base-pointer pointing to unmapped address or non-writable address, we assume its frame-pointer-omitted callee and stop trying to walk backtrace (such backtraces are reported snipped).